### PR TITLE
Site quality pass: canonical research, service pages, authorship, and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **README**: replaced the placeholder single-line README with a real one covering the tech stack, getting-started steps, project structure, content authoring, the spec-kit contribution workflow, and auto-updating status badges (Vercel deployment, live site, Next.js version, license, last commit)
 - **spec-kit**: adopted Spec-Driven Development via `.specify/` and `.claude/skills/speckit-*`, with a project-specific constitution at `.specify/memory/constitution.md` codifying specification precedence, design system discipline, accessibility, performance budget, and document integrity as gates for future feature work
+- **Service detail pages**: four canonical pages at `/services/[slug]` (strategy-brand, development, marketing, ai-data) with per-service copy, capabilities, 3–5 FAQs, and Service + FAQPage + BreadcrumbList JSON-LD; the `/services` hub links out to each and homepage service cards now link to detail pages instead of hub anchors; service data centralized in `lib/services.ts`. FAQ copy is drafted from existing positioning and pending founder review
+- **Canonical research papers**: on-site full-text hosting at `/research/[slug]` (Affective Dynamics Framework, rustif) rendered through a new plain-Markdown pipeline (`lib/markdown.ts`: remark-gfm/rehype-raw/rehype-slug/Shiki) with a sticky sidebar + collapsible table of contents; ScholarlyArticle/TechArticle JSON-LD points the canonical `url` on-site with the GitHub gist demoted to a `sameAs` mirror; adds `lib/research.ts` loader and `content/research/*.md`
+- **Blog author box**: end-of-post `AuthorBox` (photo, role, bio, social links) sourced from a new shared team registry `lib/team.ts`; BlogPosting JSON-LD author enriched with `jobTitle`, `image`, bio, and `sameAs`
+- **Blog post CTA**: reusable `PostCTA` (primary → `/contact`, secondary → `/services`) registered in the MDX component map and placed at the end of the AI Search post
+- **ShruggieGraph**: "Coming Soon" product card with an alpha waitlist CTA (`graph.shruggie.tech`) as the lead product on `/products`; footer product list updated to match
+- **Business NAP**: contact email (`info@shruggie.tech`), compliance email (`admin@shruggie.tech`), and city/state location single-sourced in `lib/constants.ts` and surfaced on the Contact page; Organization JSON-LD gains `email`
+- **Case study live-site links**: "Visit the live site" link on all three case studies via a new `liveUrl` frontmatter field
+- **Statistic citations**: all six figures in "Your Website Isn't a Brochure Anymore" now link to primary sources (SE Ranking, SparkToro, CNBC, Press Gazette, Reuters Institute, IAB Tech Lab)
+- **AI & Data service**: added AI governance / responsible-use policy and AI literacy training to the capabilities list and a new FAQ
+- `XIcon` component (current X logo) replacing the deprecated lucide Twitter bird
+- Schema generators `generateFAQSchema`, `generateBreadcrumbSchema`, and `generateResearchSchema`; `generateSoftwareSchema` `programmingLanguage` is now optional
 
 ### Removed
 
@@ -20,6 +31,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Development pillar**: added blockchain integration to the pillar description and "Blockchain architecture and smart contract development" to the capabilities list
 - **Service anchor map**: added `Blockchain`, `Smart Contracts`, and `Blockchain Consulting` entries linking to the Development & Integration pillar
+- **About "Where We Come From"**: extracted the duplicated heading and origin paragraph — which had drifted between the mobile and desktop layouts — into single `ORIGIN_HEADING`/`ORIGIN_STORY` constants
+- **Team data**: moved the About page team array into `lib/team.ts` as the single source shared by the team grid, blog author box, and JSON-LD
+- **AEO post byline**: changed from "ShruggieTech" to the human author "Natalie Thompson"
+- **Service/FAQ copy**: removed em dashes and clichéd phrasing across service descriptions and FAQs
+- **Products page**: wrapped the four product cards under a new `What We're Building` H2 (fixing an H1→H3 heading-level skip); neutralized the section label and softened the closing CTA
+- **Contact page**: reworded the social CTA to point at the follows (removing phantom-newsletter copy), made social buttons icon-only, and tightened section spacing
+- **Privacy policy**: data-subject-request and contact references now point to `admin@shruggie.tech` instead of a nonexistent "address on the Contact page"
+- **Organization JSON-LD**: dropped the registered-agent street address (kept city/state) so structured data matches the visible NAP
+- **Homepage research links**: point to on-site `/research/[slug]` instead of GitHub gists
+- **Social icons**: replaced the legacy Twitter bird with the X logo in the footer and on the Contact page
+- **Specification**: updated `ShruggieTech_Website_Specification.md` to match (confirmed contact email, NAP, and FAQ/schema examples)
+
+### Fixed
+
+- **Lenis smooth scroll**: reset scroll position on client-side route changes and route in-page anchor clicks through Lenis, fixing jumpy navigation between pages and a `SyntaxError` crash on numeric-leading heading IDs (e.g. research paper tables of contents)
+- **Blog index spacing**: added symmetric bottom padding to the post grid (the removed "Page 1 of 1" element had been the only bottom spacer)
+- **Blog pagination**: hidden entirely on single-page lists instead of rendering a "Page 1 of 1" label
+- **Product schema**: `SoftwareSourceCode` JSON-LD is emitted only for products with a public repository, so unreleased products (ShruggieGraph) don't get a fabricated repo
 
 ## [0.5.1] — 2026-03-31
 

--- a/ShruggieTech_Website_Specification.md
+++ b/ShruggieTech_Website_Specification.md
@@ -311,7 +311,7 @@ The following items require manual action by a ShruggieTech team member and cann
 | 4 | **Formspree Form ID** | Pre-launch | Create a new form at [formspree.io](https://formspree.io). Retrieve the form ID (e.g., `xpznqkdl`) and add to Vercel environment variables as `NEXT_PUBLIC_FORMSPREE_ID`. Configure the Formspree dashboard to forward submissions to the desired team email address. No backend API route is required. |
 | 5 | **Team photographs** | Content | Professional headshots for William, Natalie, and Josiah. Minimum resolution: 800x800px, square crop. Place in `public/images/team/`. Placeholder silhouettes will render in the interim. |
 | 6 | **Case study assets** | Content | Before/after screenshots and quantified outcome metrics for each case study. Client permission is already secured via original engagement contracts. The case study page template is built and ready to populate; see [§6.3](#63-work) for the example structure that demonstrates exactly what content is needed per study. Placeholder cards with "Coming Soon" badges will render until assets are provided. |
-| 7 | **Contact email address** | Pre-launch | Confirm the public-facing contact email address for the Contact page ([§6.8](#68-contact)). This address will appear on the website and receive direct inquiries. Add to the Contact page and footer once confirmed. |
+| 7 | **Contact email address** | ✅ Confirmed | Public-facing contact email is `info@shruggie.tech` (general inquiries, Contact page + Organization schema). A separate compliance inbox, `admin@shruggie.tech`, receives GDPR/CCPA data-subject requests via the Privacy policy ([§6.11](#611-privacy-policy)). Both are single-sourced as `CONTACT_EMAIL` / `PRIVACY_EMAIL` in `lib/constants.ts`. |
 | 8 | **Favicon source artwork** | Pre-development | Generate favicon assets from the kawaii shruggie logo at the following sizes: `favicon.ico` (32x32), `favicon-16x16.png`, `favicon-32x32.png`, `apple-touch-icon.png` (180x180), `android-chrome-192x192.png`, `android-chrome-512x512.png`. All PNG variants use a transparent background. Place in `public/`. See [§1.5](#15-favicon-and-web-app-manifest) for the manifest configuration. |
 
 <div style="text-align:justify">
@@ -1700,12 +1700,15 @@ export default function ContactForm() {
 }
 ```
 
-**Section 3: Direct Contact**
+**Section 3: Direct Contact (NAP)**
 
 | Element | Content |
 |---------|---------|
-| Address | 116 Agnes Rd, Ste 200, Knoxville, TN 37919 |
-| Note | "Prefer email? Reach us directly at `[contact email]`." The email address is pending confirmation; see [§1.4](#14-human-in-the-loop-requirements), item 7. A placeholder message ("Email address coming soon") renders until the address is provided. |
+| Email | `info@shruggie.tech` — rendered as a `mailto:` link (general inquiries). |
+| Location | Knoxville, TN, USA — city/state only. |
+| Phone | Intentionally omitted; no public phone number. |
+| Mailing address | **None published.** ShruggieTech has no public mailing location. The LLC's registered-agent address (116 Agnes Rd, Ste 200, Knoxville, TN 37919) is a legal-filing address only and must **not** appear as a business/NAP address on the site or in structured data ([§8.2](#82-json-ld-schema-markup)). |
+| Note | The email and location constitute the site's public NAP and must stay consistent across the Contact page, the Organization JSON-LD ([§8.2](#82-json-ld-schema-markup)), and any Google Business Profile. The Privacy policy ([§6.11](#611-privacy-policy)) uses a separate compliance inbox, `admin@shruggie.tech`, for data-subject requests. |
 
 <a name="69-audience-landing-pages" id="69-audience-landing-pages"></a>
 ### 6.9. Audience Landing Pages (`/for/...`)
@@ -1918,9 +1921,9 @@ The policy text must address the following topics at minimum. The exact legal la
 | Third-Party Services | The site uses Google Analytics 4 (privacy policy: policies.google.com/privacy), Google Tag Manager, and Formspree (privacy policy: formspree.io/legal/privacy-policy) to process form submissions. These services may set cookies or collect data as described in their respective privacy policies. |
 | Cookies | The site uses: (a) a theme preference cookie (`theme`) to persist the user's dark/light mode selection, and (b) cookies set by Google Analytics 4 for traffic measurement. Users can disable cookies via browser settings; doing so will not affect core site functionality but will reset the theme preference on each visit. |
 | Data Retention | Contact form submissions are retained in Formspree until manually deleted. Analytics data retention follows the configured GA4 property settings. |
-| Your Rights | Users may request access to, correction of, or deletion of their personal data by contacting ShruggieTech at the address listed on the Contact page. |
+| Your Rights | Users may request access to, correction of, or deletion of their personal data by emailing ShruggieTech at `admin@shruggie.tech` or using the form on the Contact page. This is a concrete data-subject-request destination — do not use a circular "address on the Contact page" reference, and do not point to a mailing address (none is published). |
 | Changes to This Policy | ShruggieTech may update this policy periodically. Changes will be reflected by updating the effective date at the top of the page. |
-| Contact | Questions about this policy can be directed to ShruggieTech at the address listed on the Contact page ([§6.8](#68-contact)). |
+| Contact | Questions about this policy can be directed to ShruggieTech at `admin@shruggie.tech` or via the Contact page ([§6.8](#68-contact)). |
 
 **Section 3: Cookie Consent Banner**
 
@@ -2271,14 +2274,17 @@ export function generateOrganizationSchema() {
     legalName: "Shruggie LLC",
     url: SITE_URL,
     logo: `${SITE_URL}/images/logo.svg`,
+    email: CONTACT_EMAIL, // info@shruggie.tech
     description:
       "A modern technical studio that builds digital systems, software, and AI-driven experiences.",
+    // City/state only. No street address is asserted: ShruggieTech has no
+    // public mailing location, and the LLC's registered-agent address is not a
+    // business location. Keeps structured data consistent with the visible NAP
+    // on /contact. Type stays Organization (not LocalBusiness) accordingly.
     address: {
       "@type": "PostalAddress",
-      streetAddress: "116 Agnes Rd, Ste 200",
       addressLocality: "Knoxville",
       addressRegion: "TN",
-      postalCode: "37919",
       addressCountry: "US",
     },
     sameAs: ["https://github.com/shruggietech"],

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -16,7 +16,7 @@ import ShruggieCTA from "@/components/ui/ShruggieCTA";
 import Card from "@/components/ui/Card";
 import CTABackground from "@/components/shared/CTABackground";
 import TeamCard from "@/components/about/TeamCard";
-import type { TeamMemberData } from "@/components/about/TeamCard";
+import { TEAM_MEMBERS } from "@/lib/team";
 import OriginIllustration from "@/components/about/OriginIllustration";
 
 /* ── Metadata ───────────────────────────────────────────────────────────── */
@@ -52,45 +52,18 @@ export const metadata: Metadata = {
   },
 };
 
-/* ── Team Data (spec §6.6, Section 3) ───────────────────────────────────── */
+/* ── Origin Story (spec §6.6, Section 2) ────────────────────────────────── */
 
-const TEAM_MEMBERS: TeamMemberData[] = [
-  {
-    name: "William Thompson",
-    title: "Co-Founder & Chief Architect",
-    description:
-      "Software architect, systems designer, and the author of ShruggieTech's internal products and published research. Background in cryptography, electronic warfare, and high-performance computing. Writes specifications that AI agents can execute without asking questions.",
-    image: "https://cdn.shruggie.tech/avatars/william-thompson-toon.jpg",
-    socials: [
-      { href: "https://www.linkedin.com/in/willthompsonpro/", label: "LinkedIn", icon: "Linkedin" },
-      { href: "https://github.com/h8rt3rmin8r", label: "GitHub", icon: "Github" },
-    ],
-  },
-  {
-    name: "Natalie Thompson",
-    title: "Co-Founder & COO",
-    description:
-      "Self-taught full-stack developer, client relationship lead, and the person who makes everything actually happen. Pairs deep technical ability with the soft skills that keep complex projects moving forward. From branding to business development, she runs point on it all.",
-    image: "https://cdn.shruggie.tech/avatars/natalie-thompson-toon.jpg",
-    socials: [
-      { href: "https://www.linkedin.com/in/cryptasian/", label: "LinkedIn", icon: "Linkedin" },
-      { href: "https://www.facebook.com/cryptasian", label: "Facebook", icon: "Facebook" },
-      { href: "https://www.instagram.com/cryptasian/", label: "Instagram", icon: "Instagram" },
-      { href: "https://github.com/cryptasian", label: "GitHub", icon: "Github" },
-    ],
-  },
-  {
-    name: "Josiah Thompson",
-    title: "Founders Assistant",
-    description:
-      "Josiah contributes to ShruggieTech's production work, assisting with social media content creation, blog article drafting, and website maintenance. His role is designed to build real professional skills early, equipping him with the technical fluency and operational discipline for a career in technology.",
-    image: "https://cdn.shruggie.tech/avatars/josiah-thompson-toon.jpg",
-    socials: [
-      { href: "https://twitch.tv/notratmaster", label: "Twitch", icon: "Twitch" },
-      { href: "https://www.youtube.com/@notratmaster", label: "YouTube", icon: "Youtube" },
-    ],
-  },
-];
+/**
+ * Single source of truth for the "Where We Come From" section. Both the
+ * mobile and desktop layouts below render from these constants — layout
+ * handles the breakpoint, the copy lives in one place so the two rendered
+ * copies can never drift apart.
+ */
+const ORIGIN_HEADING = "Where We Come From";
+
+const ORIGIN_STORY =
+  "Founded by William and Natalie Thompson, a husband-and-wife team who have been building technology together for nearly a decade. Before ShruggieTech, they ran an international consulting firm that delivered research to national governments and launch support for technology projects across multiple continents. That venture taught them how to deliver structured, high-stakes work under pressure. That same operational discipline now drives a broader mission: solving whatever technology problem stands between a business owner and their vision.";
 
 /* ── Values Data (spec §6.6, Section 4) ─────────────────────────────────── */
 
@@ -137,9 +110,9 @@ export default function AboutPage() {
             <div className="mb-8 flex justify-center">
               <OriginIllustration />
             </div>
-            <SectionHeading title="Where We Come From" />
+            <SectionHeading title={ORIGIN_HEADING} />
             <p className="mt-6 text-body-lg text-justify dark:text-[var(--text-body-light)] text-text-secondary">
-              Founded by William and Natalie Thompson, a husband-and-wife team who have been building technology together for nearly a decade. Before ShruggieTech, they ran an international consulting firm that delivered research to national governments and launch support for technology projects across multiple continents. That venture taught them how to deliver structured, high-stakes work under pressure. That same operational discipline now drives a broader mission: solving whatever technology problem stands between a business owner and their vision.
+              {ORIGIN_STORY}
             </p>
           </ScrollReveal>
         </div>
@@ -156,18 +129,9 @@ export default function AboutPage() {
                   marginLeft: 'max(var(--padding-x), calc((100% - var(--max-width-content)) / 2 + var(--padding-x)))',
                 }}
               >
-                <SectionHeading title="Where We Come From" />
+                <SectionHeading title={ORIGIN_HEADING} />
                 <p className="mt-6 text-body-lg dark:text-[var(--text-body-light)] text-text-secondary">
-                  ShruggieTech was founded by William and Natalie Thompson, a
-                  husband-and-wife team who have been building technology together
-                  for nearly a decade. Before ShruggieTech, they ran an
-                  international consulting firm that delivered research to national
-                  governments and launch support for technology projects across
-                  multiple continents. That venture taught them how to deliver
-                  structured, high-stakes work under pressure. ShruggieTech
-                  carries that same operational discipline into a broader mission:
-                  solving whatever technology problem stands between a business
-                  owner and their vision.
+                  {ORIGIN_STORY}
                 </p>
               </div>
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -24,6 +24,7 @@ import { generateBlogPostSchema } from "@/lib/schema";
 import { mdxComponents } from "@/components/blog/MDXComponents";
 import PostHeader from "@/components/blog/PostHeader";
 import TableOfContents from "@/components/blog/TableOfContents";
+import AuthorBox from "@/components/blog/AuthorBox";
 import JsonLd from "@/components/shared/JsonLd";
 
 interface BlogPostPageProps {
@@ -168,6 +169,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 },
               }}
             />
+            <AuthorBox authorName={meta.author} />
           </div>
         </div>
       </article>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -68,7 +68,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
       />
 
       {/* Post Grid */}
-      <section className="container-content pt-12 md:pt-16">
+      <section className="container-content pt-12 md:pt-16 pb-12 md:pb-16">
         {posts.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {posts.map((post) => (

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -8,21 +8,33 @@
  */
 
 import type { Metadata } from "next";
-import { Github, Facebook, Instagram, Twitter } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import type { ComponentType } from "react";
+import { Github, Facebook, Instagram, Mail, MapPin } from "lucide-react";
 
-import { SITE_URL, getOgImageUrl } from "@/lib/constants";
+import {
+  SITE_URL,
+  getOgImageUrl,
+  CONTACT_EMAIL,
+  BUSINESS_LOCATION,
+} from "@/lib/constants";
+import XIcon from "@/components/icons/XIcon";
 import ScrollReveal from "@/components/shared/ScrollReveal";
 import ContactForm from "@/components/ContactForm";
 import PageHero from "@/components/shared/PageHero";
 import Card from "@/components/ui/Card";
 import CTABackground from "@/components/shared/CTABackground";
 
-const SOCIAL_LINKS: { href: string; label: string; Icon: LucideIcon }[] = [
+type SocialIcon = ComponentType<{
+  size?: number;
+  className?: string;
+  "aria-hidden"?: boolean | "true" | "false";
+}>;
+
+const SOCIAL_LINKS: { href: string; label: string; Icon: SocialIcon }[] = [
   { href: "https://github.com/shruggietech", label: "GitHub", Icon: Github },
   { href: "https://www.facebook.com/shruggietech", label: "Facebook", Icon: Facebook },
   { href: "https://www.instagram.com/shruggietech", label: "Instagram", Icon: Instagram },
-  { href: "https://x.com/shruggietech", label: "X (Twitter)", Icon: Twitter },
+  { href: "https://x.com/shruggietech", label: "X", Icon: XIcon },
 ];
 
 /* ── Metadata ───────────────────────────────────────────────────────────── */
@@ -73,10 +85,26 @@ export default function ContactPage() {
       {/* ── Section 2: Social Media + Contact Form ────────────────────── */}
       <CTABackground className="pt-8 pb-52 md:pt-12 md:pb-96">
         <div className="container-content">
+          {/* Direct contact info — NAP (email + location) */}
+          <ScrollReveal>
+            <div className="flex flex-col items-center justify-center gap-4 text-center sm:flex-row sm:gap-8">
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="flex items-center gap-2 text-body text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+              >
+                <Mail size={20} aria-hidden="true" />
+                <span className="font-medium">{CONTACT_EMAIL}</span>
+              </a>
+              <p className="flex items-center gap-2 text-body text-text-secondary">
+                <MapPin size={20} aria-hidden="true" />
+                <span className="font-medium">{BUSINESS_LOCATION}</span>
+              </p>
+            </div>
+          </ScrollReveal>
           <ScrollReveal>
             <div className="mb-12 text-center">
               <p className="mx-auto mt-12 max-w-lg text-body text-text-secondary">
-                Stay up to date with our latest work, research, and insights.
+                Follow us for our latest work, research, and insights.
               </p>
               <div className="mt-8 flex items-center justify-center gap-6">
                 {SOCIAL_LINKS.map((link) => (
@@ -86,12 +114,9 @@ export default function ContactPage() {
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label={link.label}
-                    className="flex items-center gap-2 rounded-lg border border-border bg-bg-secondary px-4 py-3 text-text-secondary transition-colors duration-200 hover:border-brand-green-bright hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                    className="flex items-center justify-center rounded-lg border border-border bg-bg-secondary p-3 text-text-secondary transition-colors duration-200 hover:border-brand-green-bright hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
                   >
                     <link.Icon size={20} aria-hidden="true" />
-                    <span className="text-body-sm font-medium hidden sm:inline">
-                      {link.label}
-                    </span>
                   </a>
                 ))}
               </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -11,7 +11,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { getOgImageUrl } from "@/lib/constants";
+import { getOgImageUrl, PRIVACY_EMAIL } from "@/lib/constants";
 import PageHero from "@/components/shared/PageHero";
 
 export const metadata: Metadata = {
@@ -167,8 +167,14 @@ export default function PrivacyPolicyPage() {
           <h2>Your Rights</h2>
           <p>
             You may request access to, correction of, or deletion of your
-            personal data by contacting ShruggieTech at the address listed on
-            our{" "}
+            personal data by emailing ShruggieTech at{" "}
+            <a
+              href={`mailto:${PRIVACY_EMAIL}`}
+              className="text-accent hover:text-accent-hover"
+            >
+              {PRIVACY_EMAIL}
+            </a>{" "}
+            or using the form on our{" "}
             <Link href="/contact" className="text-accent hover:text-accent-hover">
               Contact page
             </Link>
@@ -185,8 +191,14 @@ export default function PrivacyPolicyPage() {
           {/* Contact */}
           <h2>Contact</h2>
           <p>
-            Questions about this policy can be directed to ShruggieTech at the
-            address listed on our{" "}
+            Questions about this policy can be directed to ShruggieTech at{" "}
+            <a
+              href={`mailto:${PRIVACY_EMAIL}`}
+              className="text-accent hover:text-accent-hover"
+            >
+              {PRIVACY_EMAIL}
+            </a>{" "}
+            or via our{" "}
             <Link href="/contact" className="text-accent hover:text-accent-hover">
               Contact page
             </Link>

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -8,13 +8,16 @@
  */
 
 import type { Metadata } from "next";
+import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
 import {
   ExternalLink,
+  ArrowRight,
   Package,
   Database,
   FileText,
   Cpu,
+  Network,
 } from "lucide-react";
 
 import { SITE_URL, getOgImageUrl } from "@/lib/constants";
@@ -67,6 +70,8 @@ export const metadata: Metadata = {
 interface ProductLink {
   label: string;
   href: string;
+  /** Internal route — rendered as a same-tab Next link, not an external one. */
+  internal?: boolean;
 }
 
 interface Product {
@@ -75,13 +80,25 @@ interface Product {
   description: string;
   statusBadge: string;
   links: ProductLink[];
-  programmingLanguage: string;
-  codeRepository: string;
+  /** Optional: unreleased products (e.g. private alpha) have no public repo. */
+  programmingLanguage?: string;
+  codeRepository?: string;
   version?: string;
   icon: LucideIcon;
 }
 
 const PRODUCTS: Product[] = [
+  {
+    id: "shruggiegraph",
+    name: "ShruggieGraph",
+    description:
+      "A permission-scoped, source-backed memory graph for AI. ShruggieGraph captures durable knowledge from your conversations and lets any AI assistant recall it across sessions and providers, with every fact traceable to the source it came from.",
+    statusBadge: "Coming Soon",
+    links: [
+      { label: "Join the alpha waitlist", href: "https://graph.shruggie.tech/#waitlist" },
+    ],
+    icon: Network,
+  },
   {
     id: "shruggie-indexer",
     name: "shruggie-indexer",
@@ -130,10 +147,10 @@ const PRODUCTS: Product[] = [
       "A proposed Rust-native metadata processing engine. The next-generation successor to thirty years of metadata infrastructure.",
     statusBadge: "Declaration Phase",
     links: [
-      { label: "Read Declaration", href: "https://gist.github.com/h8rt3rmin8r/b20a59e60f039b7a8bccbf67288226de" },
+      { label: "Read Declaration", href: "/research/rustif", internal: true },
     ],
     programmingLanguage: "Rust",
-    codeRepository: "https://gist.github.com/h8rt3rmin8r/b20a59e60f039b7a8bccbf67288226de",
+    codeRepository: `${SITE_URL}/research/rustif`,
     icon: Cpu,
   },
 ];
@@ -143,15 +160,17 @@ const PRODUCTS: Product[] = [
 export default function ProductsPage() {
   return (
     <>
-      {/* JSON-LD for each product */}
-      {PRODUCTS.map((product) => (
+      {/* JSON-LD — only for products with a public code repository. Unreleased
+          products (e.g. ShruggieGraph in private alpha) get no SoftwareSourceCode
+          schema rather than a fabricated repo. */}
+      {PRODUCTS.filter((product) => product.codeRepository).map((product) => (
         <JsonLd
           key={product.id}
           data={generateSoftwareSchema({
             name: product.name,
             description: product.description,
             url: `${SITE_URL}/products`,
-            codeRepository: product.codeRepository,
+            codeRepository: product.codeRepository!,
             programmingLanguage: product.programmingLanguage,
             version: product.version,
           })}
@@ -168,7 +187,10 @@ export default function ProductsPage() {
       {/* Product Cards */}
       <section className="bg-bg-primary pb-16 md:pb-24">
         <div className="container-content pt-16 md:pt-24">
-          <div className="grid gap-8 md:grid-cols-2">
+          <ScrollReveal>
+            <SectionHeading title="What We're Building" />
+          </ScrollReveal>
+          <div className="mt-12 grid gap-8 md:grid-cols-2">
             {PRODUCTS.map((product, i) => {
               const Icon = product.icon;
               return (
@@ -185,18 +207,32 @@ export default function ProductsPage() {
                       {product.description}
                     </p>
                     <div className="mt-6 flex flex-wrap gap-4">
-                      {product.links.map((link) => (
-                        <a
-                          key={link.label}
-                          href={link.href}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1.5 font-display text-body-sm font-medium text-accent transition-colors hover:text-[#FF5300]"
-                        >
-                          {link.label}
-                          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-                        </a>
-                      ))}
+                      {product.links.map((link) =>
+                        link.internal ? (
+                          <Link
+                            key={link.label}
+                            href={link.href}
+                            className="group/link inline-flex items-center gap-1.5 font-display text-body-sm font-medium text-accent transition-colors hover:text-[#FF5300]"
+                          >
+                            {link.label}
+                            <ArrowRight
+                              className="h-3.5 w-3.5 transition-transform group-hover/link:translate-x-0.5"
+                              aria-hidden="true"
+                            />
+                          </Link>
+                        ) : (
+                          <a
+                            key={link.label}
+                            href={link.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 font-display text-body-sm font-medium text-accent transition-colors hover:text-[#FF5300]"
+                          >
+                            {link.label}
+                            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                          </a>
+                        ),
+                      )}
                     </div>
                   </Card>
                 </ScrollReveal>
@@ -235,7 +271,7 @@ export default function ProductsPage() {
         <div className="container-content text-center">
           <ScrollReveal>
             <h2 className="font-display text-display-md font-bold text-text-primary">
-              The code is open. Jump in.
+              Explore our open source work.
             </h2>
             <div className="mt-8">
               <ShruggieCTA href="https://github.com/shruggietech">View on GitHub</ShruggieCTA>

--- a/app/research/[slug]/page.tsx
+++ b/app/research/[slug]/page.tsx
@@ -1,0 +1,188 @@
+/**
+ * Research paper page — /research/[slug]
+ *
+ * Canonical, on-site version of each publication (previously only on GitHub
+ * gists). Renders the full paper as Markdown, emits ScholarlyArticle or
+ * TechArticle JSON-LD whose canonical `url` is this page, and links the gist
+ * as a mirror (`sameAs`). Statically generated from content/research/.
+ *
+ * Spec reference: §6.4 (Research and Publications), §8.2 (JSON-LD)
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, Github } from "lucide-react";
+
+import { SITE_URL, getOgImageUrl } from "@/lib/constants";
+import {
+  getAllResearchMeta,
+  getResearchBySlug,
+} from "@/lib/research";
+import { renderMarkdown } from "@/lib/markdown";
+import { generateResearchSchema } from "@/lib/schema";
+import JsonLd from "@/components/shared/JsonLd";
+import TableOfContents from "@/components/blog/TableOfContents";
+
+interface ResearchPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+/* ── Static generation ──────────────────────────────────────────────────── */
+
+export function generateStaticParams() {
+  return getAllResearchMeta().map((paper) => ({ slug: paper.slug }));
+}
+
+/* ── Metadata ───────────────────────────────────────────────────────────── */
+
+export async function generateMetadata({
+  params,
+}: ResearchPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const paper = getResearchBySlug(slug);
+
+  if (!paper) {
+    return { title: "Paper Not Found" };
+  }
+
+  const { meta } = paper;
+  const url = `${SITE_URL}/research/${meta.slug}`;
+  const ogImage = getOgImageUrl(meta.title, { author: meta.author });
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    keywords: meta.keywords,
+    authors: [{ name: meta.author }],
+    alternates: { canonical: url },
+    openGraph: {
+      title: `${meta.title} | ShruggieTech`,
+      description: meta.description,
+      url,
+      type: "article",
+      publishedTime: meta.date,
+      modifiedTime: meta.dateModified,
+      authors: [meta.author],
+      images: [{ url: ogImage, width: 1200, height: 630, alt: meta.title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${meta.title} | ShruggieTech`,
+      description: meta.description,
+      images: [ogImage],
+    },
+  };
+}
+
+/* ── Page ───────────────────────────────────────────────────────────────── */
+
+export default async function ResearchPaperPage({ params }: ResearchPageProps) {
+  const { slug } = await params;
+  const paper = getResearchBySlug(slug);
+
+  if (!paper) {
+    notFound();
+  }
+
+  const { meta, content } = paper;
+  const { html, toc } = await renderMarkdown(content);
+  const url = `${SITE_URL}/research/${meta.slug}`;
+
+  const dateFormatted = new Date(meta.date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <>
+      <JsonLd
+        data={generateResearchSchema({
+          type: meta.schemaType,
+          title: meta.title,
+          author: meta.author,
+          datePublished: meta.date,
+          dateModified: meta.dateModified,
+          description: meta.description,
+          url,
+          sameAs: meta.gistUrl ? [meta.gistUrl] : undefined,
+          keywords: meta.keywords,
+        })}
+      />
+
+      <article className="py-20">
+        {/* Header */}
+        <div className="mx-auto max-w-[900px] px-[var(--padding-x)]">
+          <Link
+            href="/research"
+            className="inline-flex items-center gap-2 text-body-sm text-text-secondary transition-colors hover:text-accent"
+          >
+            <ArrowLeft size={16} aria-hidden="true" />
+            Back to Research
+          </Link>
+
+          <h1 className="mt-8 font-display text-display-md font-bold text-text-primary">
+            {meta.title}
+          </h1>
+
+          {meta.subtitle && (
+            <p className="mt-4 text-body-lg text-text-secondary">
+              {meta.subtitle}
+            </p>
+          )}
+
+          <div className="mt-6 flex flex-wrap items-center gap-x-3 gap-y-1 text-body-sm text-text-muted">
+            <span>{meta.author}</span>
+            <span aria-hidden="true">·</span>
+            <time dateTime={meta.date}>{dateFormatted}</time>
+            <span aria-hidden="true">·</span>
+            <span>{meta.readingTime}</span>
+          </div>
+
+          {/* Mirror notice — this page is canonical; the gist is a mirror */}
+          {meta.gistUrl && (
+            <div className="mt-8 rounded-lg border border-border bg-bg-elevated p-4 text-body-sm text-text-secondary dark:border-white/[0.06] dark:bg-white/[0.02]">
+              This is the canonical version of this paper. A mirror is also
+              published on{" "}
+              <a
+                href={meta.gistUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-medium text-accent hover:text-accent-hover"
+              >
+                <Github size={14} aria-hidden="true" />
+                GitHub
+              </a>
+              .
+            </div>
+          )}
+
+          <div className="mt-8 border-t border-accent/10" />
+        </div>
+
+        {/* Collapsible ToC for screens below xl — sticky below header */}
+        {toc.length > 0 && (
+          <div className="sticky top-16 z-10 mt-8 bg-bg-primary py-3 xl:hidden">
+            <div className="mx-auto max-w-[900px] px-[var(--padding-x)]">
+              <TableOfContents headings={toc} collapsible />
+            </div>
+          </div>
+        )}
+
+        {/* Body — optional desktop ToC sidebar */}
+        <div className="mx-auto mt-10 max-w-[900px] px-[var(--padding-x)] xl:flex xl:max-w-[1400px] xl:gap-16">
+          {toc.length > 0 && (
+            <aside className="hidden w-[260px] shrink-0 xl:block">
+              <TableOfContents headings={toc} className="sticky top-24" />
+            </aside>
+          )}
+          <div
+            className="prose prose-lg dark:prose-invert mx-auto min-w-0 max-w-none flex-1 xl:mx-0 prose-pre:bg-transparent prose-pre:m-0 prose-pre:border-0 [&_h2]:scroll-mt-24 [&_h3]:scroll-mt-24 [&_h4]:scroll-mt-24 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_pre_span]:!bg-transparent [&_table]:block [&_table]:overflow-x-auto"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        </div>
+      </article>
+    </>
+  );
+}

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -10,10 +10,12 @@
 
 import type { Metadata } from "next";
 import type { ComponentType } from "react";
-import { ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 
 import { SITE_URL, getOgImageUrl } from "@/lib/constants";
-import { generateTechArticleSchema } from "@/lib/schema";
+import { getAllResearchMeta } from "@/lib/research";
+import { generateResearchSchema } from "@/lib/schema";
 import JsonLd from "@/components/shared/JsonLd";
 import PageHero from "@/components/shared/PageHero";
 import ScrollReveal from "@/components/shared/ScrollReveal";
@@ -60,55 +62,37 @@ export const metadata: Metadata = {
 
 /* ── Publication Data (spec §6.4) ───────────────────────────────────────── */
 
-interface Publication {
-  id: string;
-  title: string;
-  author: string;
-  description: string;
-  datePublished: string;
-  href: string;
-  Visual: ComponentType;
-}
+/** Decorative visual per paper, keyed by slug. */
+const VISUAL_MAP: Record<string, ComponentType> = {
+  "affective-dynamics": ADFVisual,
+  rustif: RustifVisual,
+};
 
-const PUBLICATIONS: Publication[] = [
-  {
-    id: "adf",
-    title:
-      "Affective Dynamics Framework: A Systematic Approach to Simulating Human-Like Emotional States and Relational Bonding in AI Agents",
-    author: "William Thompson",
-    description:
-      "A mathematically grounded specification for producing emergent, non-linear emotional behavior and relational bonding in AI agents. Extends Brian Roemmele's Love Equation into a real-time personality engine for agentic architectures.",
-    datePublished: "2025-01-15",
-    href: "https://gist.github.com/h8rt3rmin8r/f4589f0afb6fcd10d4c499e4a29247ad",
-    Visual: ADFVisual,
-  },
-  {
-    id: "rustif-declaration",
-    title: "rustif: A Next-Generation Metadata Processing Engine",
-    author: "William Thompson",
-    description:
-      "The case for building a Rust-native metadata processing engine to succeed ExifTool. Ecosystem analysis, architectural specification, security threat model, and a call for contributors.",
-    datePublished: "2025-03-01",
-    href: "https://gist.github.com/h8rt3rmin8r/b20a59e60f039b7a8bccbf67288226de",
-    Visual: RustifVisual,
-  },
-];
+const PUBLICATIONS = getAllResearchMeta().map((meta) => ({
+  ...meta,
+  href: `/research/${meta.slug}`,
+  Visual: VISUAL_MAP[meta.slug],
+}));
 
 /* ── Page ────────────────────────────────────────────────────────────────── */
 
 export default function ResearchPage() {
   return (
     <>
-      {/* JSON-LD for each publication */}
+      {/* JSON-LD for each publication — canonical on-site URL, gist as mirror */}
       {PUBLICATIONS.map((pub) => (
         <JsonLd
-          key={pub.id}
-          data={generateTechArticleSchema({
+          key={pub.slug}
+          data={generateResearchSchema({
+            type: pub.schemaType,
             title: pub.title,
             author: pub.author,
-            datePublished: pub.datePublished,
+            datePublished: pub.date,
+            dateModified: pub.dateModified,
             description: pub.description,
-            url: pub.href === "#" ? `${SITE_URL}/research` : pub.href,
+            url: `${SITE_URL}${pub.href}`,
+            sameAs: pub.gistUrl ? [pub.gistUrl] : undefined,
+            keywords: pub.keywords,
           })}
         />
       ))}
@@ -124,11 +108,9 @@ export default function ResearchPage() {
       <section className="section-bg-research pb-24 md:pb-32">
         <div className="container-content flex flex-col gap-8 md:gap-12">
           {PUBLICATIONS.map((pub, i) => (
-            <ScrollReveal key={pub.id} delay={i * 0.1}>
-              <a
+            <ScrollReveal key={pub.slug} delay={i * 0.1}>
+              <Link
                 href={pub.href}
-                target="_blank"
-                rel="noopener noreferrer"
                 className="group/card block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-[#111318] rounded-xl"
               >
                 <Card hover>
@@ -146,17 +128,20 @@ export default function ResearchPage() {
                       </p>
                       <span className="mt-6 inline-flex items-center gap-2 font-display text-body-md font-medium text-accent transition-colors group-hover/card:text-[#FF5300]">
                         Read paper
-                        <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                        <ArrowRight
+                          className="h-4 w-4 transition-transform group-hover/card:translate-x-1"
+                          aria-hidden="true"
+                        />
                       </span>
                     </div>
 
                     {/* Right column: abstract visual (desktop only) */}
                     <div className="hidden md:flex md:w-[40%] md:items-center md:justify-center">
-                      <pub.Visual />
+                      {pub.Visual && <pub.Visual />}
                     </div>
                   </div>
                 </Card>
-              </a>
+              </Link>
             </ScrollReveal>
           ))}
         </div>

--- a/app/services/ServicePillarSection.tsx
+++ b/app/services/ServicePillarSection.tsx
@@ -12,8 +12,9 @@
 "use client";
 
 import { useRef } from "react";
+import Link from "next/link";
 import { useInView, useReducedMotion } from "framer-motion";
-import { Palette, Code2, TrendingUp, Brain } from "lucide-react";
+import { Palette, Code2, TrendingUp, Brain, ArrowRight } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import ScrollReveal from "@/components/shared/ScrollReveal";
@@ -56,6 +57,8 @@ interface ServicePillarSectionProps {
   capabilities: string[];
   index: number;
   bgClass: string;
+  /** Optional link to the service's dedicated detail page. */
+  detailHref?: string;
 }
 
 export default function ServicePillarSection({
@@ -66,6 +69,7 @@ export default function ServicePillarSection({
   capabilities,
   index,
   bgClass,
+  detailHref,
 }: ServicePillarSectionProps) {
   const sectionRef = useRef<HTMLElement>(null);
   const illustrationRef = useRef<HTMLDivElement>(null);
@@ -136,6 +140,20 @@ export default function ServicePillarSection({
                   </li>
                 ))}
               </ul>
+
+              {detailHref && (
+                <Link
+                  href={detailHref}
+                  className="group mt-8 inline-flex items-center gap-2 font-display text-body-md font-medium text-accent hover:text-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                >
+                  Explore {title}
+                  <ArrowRight
+                    size={18}
+                    aria-hidden="true"
+                    className="transition-transform duration-300 group-hover:translate-x-1"
+                  />
+                </Link>
+              )}
             </div>
           </div>
         </ScrollReveal>

--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -1,0 +1,239 @@
+/**
+ * Service detail page — /services/[slug]
+ *
+ * One dedicated page per service pillar (strategy-brand, development,
+ * marketing, ai-data), with full copy, capabilities, real FAQs, and both
+ * Service + FAQPage JSON-LD. Statically generated from lib/services.ts.
+ *
+ * This implements the flagship post's guidance: give important services their
+ * own pages instead of one crowded list, with FAQs marked up as FAQPage.
+ *
+ * Spec reference: §6.2 (Services), §8.2 (JSON-LD)
+ */
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowRight, ChevronRight } from "lucide-react";
+
+import { SITE_URL, getOgImageUrl } from "@/lib/constants";
+import { SERVICES, getServiceBySlug } from "@/lib/services";
+import {
+  generateServiceSchema,
+  generateFAQSchema,
+  generateBreadcrumbSchema,
+} from "@/lib/schema";
+import JsonLd from "@/components/shared/JsonLd";
+import PageHero from "@/components/shared/PageHero";
+import ScrollReveal from "@/components/shared/ScrollReveal";
+import CTABackground from "@/components/shared/CTABackground";
+import SectionHeading from "@/components/ui/SectionHeading";
+import ShruggieCTA from "@/components/ui/ShruggieCTA";
+import ServiceFAQ from "@/components/services/ServiceFAQ";
+
+interface ServiceDetailPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+/* ── Static generation ──────────────────────────────────────────────────── */
+
+export function generateStaticParams() {
+  return SERVICES.map((service) => ({ slug: service.slug }));
+}
+
+/* ── Metadata ───────────────────────────────────────────────────────────── */
+
+export async function generateMetadata({
+  params,
+}: ServiceDetailPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const service = getServiceBySlug(slug);
+
+  if (!service) {
+    return { title: "Service Not Found" };
+  }
+
+  const url = `${SITE_URL}/services/${service.slug}`;
+  const ogImage = getOgImageUrl(service.title, {
+    description: service.metaDescription,
+  });
+
+  return {
+    title: service.title,
+    description: service.metaDescription,
+    alternates: { canonical: url },
+    openGraph: {
+      title: `${service.title} | ShruggieTech`,
+      description: service.metaDescription,
+      url,
+      type: "website",
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: `${service.title} | ShruggieTech`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${service.title} | ShruggieTech`,
+      description: service.metaDescription,
+      images: [ogImage],
+    },
+  };
+}
+
+/* ── Page Component ─────────────────────────────────────────────────────── */
+
+export default async function ServiceDetailPage({
+  params,
+}: ServiceDetailPageProps) {
+  const { slug } = await params;
+  const service = getServiceBySlug(slug);
+
+  if (!service) {
+    notFound();
+  }
+
+  const url = `${SITE_URL}/services/${service.slug}`;
+  const otherServices = SERVICES.filter((s) => s.slug !== service.slug);
+
+  return (
+    <>
+      {/* JSON-LD: Service + FAQPage + BreadcrumbList */}
+      <JsonLd
+        data={generateServiceSchema({
+          name: service.title,
+          description: service.lead,
+        })}
+      />
+      <JsonLd data={generateFAQSchema(service.faqs)} />
+      <JsonLd
+        data={generateBreadcrumbSchema([
+          { name: "Services", url: `${SITE_URL}/services` },
+          { name: service.shortName, url },
+        ])}
+      />
+
+      {/* ── Hero ─────────────────────────────────────────────────────── */}
+      <PageHero
+        headline={service.title}
+        subheadline={service.lead}
+        bgClass="section-bg-services"
+      >
+        {/* Breadcrumb */}
+        <nav aria-label="Breadcrumb" className="mt-8">
+          <ol className="flex items-center gap-2 text-body-sm text-text-secondary">
+            <li>
+              <Link href="/services" className="hover:text-accent">
+                Services
+              </Link>
+            </li>
+            <li aria-hidden="true">
+              <ChevronRight size={14} className="text-text-muted" />
+            </li>
+            <li className="text-text-primary font-medium">
+              {service.shortName}
+            </li>
+          </ol>
+        </nav>
+      </PageHero>
+
+      {/* ── Overview + Capabilities ──────────────────────────────────── */}
+      <section className="bg-bg-primary py-16 md:py-24">
+        <div className="container-content">
+          <ScrollReveal>
+            <div className="max-w-3xl">
+              <p className="text-body-lg text-text-secondary">{service.body}</p>
+            </div>
+          </ScrollReveal>
+
+          <ScrollReveal>
+            <div className="mt-12">
+              <h2 className="font-display text-display-sm font-bold text-text-primary">
+                What we do
+              </h2>
+              <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {service.capabilities.map((capability) => (
+                  <li
+                    key={capability}
+                    className="flex items-start gap-3 text-body-md text-text-secondary"
+                  >
+                    <span
+                      className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-accent"
+                      aria-hidden="true"
+                    />
+                    {capability}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* ── FAQ ──────────────────────────────────────────────────────── */}
+      <section className="section-bg-services py-16 md:py-24">
+        <div className="container-content">
+          <ScrollReveal>
+            <SectionHeading
+              label="FAQ"
+              title="Frequently asked questions"
+            />
+          </ScrollReveal>
+          <ScrollReveal>
+            <div className="max-w-3xl">
+              <ServiceFAQ faqs={service.faqs} />
+            </div>
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* ── Other services ───────────────────────────────────────────── */}
+      <section className="bg-bg-primary py-16 md:py-24">
+        <div className="container-content">
+          <ScrollReveal>
+            <h2 className="font-display text-display-sm font-bold text-text-primary">
+              Explore other services
+            </h2>
+            <ul className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+              {otherServices.map((other) => (
+                <li key={other.slug}>
+                  <Link
+                    href={`/services/${other.slug}`}
+                    className="group flex items-center justify-between gap-3 rounded-xl border border-border bg-bg-elevated p-5 transition-colors duration-300 hover:border-accent/40 dark:border-white/[0.06] dark:bg-white/[0.02]"
+                  >
+                    <span className="font-display text-body-lg font-bold text-text-primary">
+                      {other.shortName}
+                    </span>
+                    <ArrowRight
+                      size={18}
+                      aria-hidden="true"
+                      className="shrink-0 text-accent transition-transform duration-300 group-hover:translate-x-1"
+                    />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* ── CTA ──────────────────────────────────────────────────────── */}
+      <CTABackground>
+        <div className="container-content text-center">
+          <ScrollReveal>
+            <h2 className="font-display text-display-md font-bold text-text-primary">
+              Let&apos;s scope your project.
+            </h2>
+            <div className="mt-8">
+              <ShruggieCTA href="/contact">Get in Touch</ShruggieCTA>
+            </div>
+          </ScrollReveal>
+        </div>
+      </CTABackground>
+    </>
+  );
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -11,6 +11,7 @@
 import type { Metadata } from "next";
 
 import { SITE_URL, getOgImageUrl } from "@/lib/constants";
+import { SERVICES } from "@/lib/services";
 import { generateServiceSchema } from "@/lib/schema";
 import JsonLd from "@/components/shared/JsonLd";
 import PageHero from "@/components/shared/PageHero";
@@ -55,88 +56,18 @@ export const metadata: Metadata = {
   },
 };
 
-/* ── Service Pillar Data ────────────────────────────────────────────────── */
-
-interface ServicePillar {
-  id: string;
-  title: string;
-  lead: string;
-  body: string;
-  capabilities: string[];
-}
-
-const SERVICE_PILLARS: ServicePillar[] = [
-  {
-    id: "strategy-brand",
-    title: "Digital Strategy & Brand",
-    lead: "Your brand is the first thing people see and the last thing they remember. We make both count.",
-    body: "We build visual identity systems, brand standards kits, and content architecture from scratch, or refresh what already exists. Your brand should translate consistently across every platform and touchpoint, and we make sure it does.",
-    capabilities: [
-      "Logo design and visual identity systems",
-      "Color palette and typography systems",
-      "Brand standards kits",
-      "Website strategy and content architecture",
-      "Marketing collateral and print materials",
-    ],
-  },
-  {
-    id: "development",
-    title: "Development & Integration",
-    lead: "We build, migrate, and integrate. From marketing sites to custom applications, we handle the full technical stack.",
-    body: "We work across whatever stack fits the project, not whatever stack we prefer. New build, migration, blockchain integration, or a compatibility layer over systems you can't replace, the approach is shaped by your situation, not ours.",
-    capabilities: [
-      "Custom website design and development",
-      "Modern web applications",
-      "CMS deployment, configuration, and migration",
-      "Blockchain architecture and smart contract development",
-      "Third-party integrations",
-      "DNS management and hosting configuration",
-      "Vendor displacement and replatforming",
-    ],
-  },
-  {
-    id: "marketing",
-    title: "Revenue Flows & Marketing Operations",
-    lead: "Visibility means nothing without conversion. We build the systems that turn attention into revenue.",
-    body: "Every business converts differently. A tour operator needs marketplace visibility. A local shop needs to own local search. An e-commerce brand needs a conversion funnel that doesn't leak. We tailor the strategy to how your customers actually find and buy from you.",
-    capabilities: [
-      "SEO strategy and execution",
-      "Answer Engine Optimization (AEO) with schema markup",
-      "Google Ads and Meta advertising",
-      "Social media strategy and content planning",
-      "Analytics implementation (GA4, GTM, Search Console)",
-      "Review generation and reputation management",
-      "Marketplace and platform listing optimization",
-    ],
-  },
-  {
-    id: "ai-data",
-    title: "AI & Data Analysis",
-    lead: "AI is not magic. It is infrastructure. We help you build AI systems that solve real problems.",
-    body: "Most businesses don't need a custom model. They need AI wired into the systems they already use: answering customer questions, automating repetitive workflows, or surfacing the right data at the right time. We figure out where AI actually helps and build it into your operations.",
-    capabilities: [
-      "Conversational AI and chatbot development",
-      "RAG system design and implementation",
-      "Semantic and vector search integration",
-      "Workflow automation (email/SMS pipelines, process optimization)",
-      "AI adoption consulting",
-      "Multi-agent coding workflow design",
-    ],
-  },
-];
-
 /* ── Page Component ─────────────────────────────────────────────────────── */
 
 export default function ServicesPage() {
   return (
     <>
       {/* JSON-LD: Service schema for each pillar */}
-      {SERVICE_PILLARS.map((pillar) => (
+      {SERVICES.map((service) => (
         <JsonLd
-          key={pillar.id}
+          key={service.slug}
           data={generateServiceSchema({
-            name: pillar.title,
-            description: pillar.lead,
+            name: service.title,
+            description: service.lead,
           })}
         />
       ))}
@@ -149,16 +80,17 @@ export default function ServicesPage() {
       />
 
       {/* ── Section 2: Service Pillars ───────────────────────────────── */}
-      {SERVICE_PILLARS.map((pillar, index) => (
+      {SERVICES.map((service, index) => (
         <ServicePillarSection
-          key={pillar.id}
-          id={pillar.id}
-          title={pillar.title}
-          lead={pillar.lead}
-          body={pillar.body}
-          capabilities={pillar.capabilities}
+          key={service.slug}
+          id={service.slug}
+          title={service.title}
+          lead={service.lead}
+          body={service.body}
+          capabilities={service.capabilities}
           index={index}
           bgClass={index % 2 === 0 ? "bg-bg-primary" : "section-bg-services"}
+          detailHref={`/services/${service.slug}`}
         />
       ))}
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -11,14 +11,18 @@ import { MetadataRoute } from "next";
 
 import { getAllPostsMeta } from "@/lib/blog";
 import { getAllCaseStudiesMeta } from "@/lib/work";
+import { getAllResearchMeta } from "@/lib/research";
 import { SITE_URL } from "@/lib/constants";
+import { SERVICE_SLUGS } from "@/lib/services";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages = [
     "",
     "/services",
+    ...SERVICE_SLUGS.map((slug) => `/services/${slug}`),
     "/work",
     "/research",
+    ...getAllResearchMeta().map((paper) => `/research/${paper.slug}`),
     "/products",
     "/about",
     "/blog",

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -17,6 +17,7 @@ import fs from "fs";
 import path from "path";
 
 import Link from "next/link";
+import { ExternalLink } from "lucide-react";
 
 import { SITE_URL, getOgImageUrl } from "@/lib/constants";
 import { SERVICE_ANCHOR_MAP } from "@/lib/service-links";
@@ -125,6 +126,22 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
             {meta.client}
           </span>
         </div>
+
+        {meta.liveUrl && (
+          <a
+            href={meta.liveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group mt-6 inline-flex items-center gap-2 rounded-lg border border-accent/30 px-4 py-2 font-display text-body-sm font-medium text-accent transition-colors hover:border-accent hover:bg-accent/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+          >
+            Visit the live site
+            <ExternalLink
+              size={16}
+              aria-hidden="true"
+              className="transition-transform group-hover:translate-x-0.5"
+            />
+          </a>
+        )}
       </PageHero>
 
       {/* Full-Width DeviceMockup Screenshot */}

--- a/components/about/TeamCard.tsx
+++ b/components/about/TeamCard.tsx
@@ -21,6 +21,8 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
+import type { TeamMemberData } from "@/lib/team";
+
 const ICON_MAP: Record<string, LucideIcon> = {
   Linkedin,
   Github,
@@ -29,20 +31,6 @@ const ICON_MAP: Record<string, LucideIcon> = {
   Twitch,
   Youtube,
 };
-
-export interface SocialLink {
-  href: string;
-  label: string;
-  icon: string; // key into ICON_MAP
-}
-
-export interface TeamMemberData {
-  name: string;
-  title: string;
-  description: string;
-  image: string;
-  socials: SocialLink[];
-}
 
 interface TeamCardProps {
   member: TeamMemberData;

--- a/components/blog/AuthorBox.tsx
+++ b/components/blog/AuthorBox.tsx
@@ -1,0 +1,91 @@
+/**
+ * AuthorBox — Named-author byline box for the end of a blog post.
+ *
+ * Renders the post author's photo, name, role, bio, and social links, sourced
+ * from the shared team registry (lib/team.ts). A named human author with a bio
+ * and outbound social links is what Google's authorship guidance and AI
+ * citation heuristics reward — and it backs up the site's "Published by
+ * humans" claim. Returns null if the byline is not a known person.
+ *
+ * Spec reference: §7.3 (Blog Post Template), §8.2 (JSON-LD authorship)
+ */
+
+import Image from "next/image";
+import Link from "next/link";
+import {
+  Linkedin,
+  Github,
+  Facebook,
+  Instagram,
+  Twitch,
+  Youtube,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { getAuthorByName } from "@/lib/team";
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  Linkedin,
+  Github,
+  Facebook,
+  Instagram,
+  Twitch,
+  Youtube,
+};
+
+export default function AuthorBox({ authorName }: { authorName: string }) {
+  const author = getAuthorByName(authorName);
+  if (!author) return null;
+
+  return (
+    <aside className="not-prose mt-16 rounded-xl border border-border bg-bg-elevated p-6 md:p-8 dark:border-white/[0.06] dark:bg-white/[0.02]">
+      <p className="mb-4 text-body-sm font-medium uppercase tracking-widest text-accent">
+        Written by
+      </p>
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+        <div className="h-20 w-20 shrink-0 overflow-hidden rounded-full">
+          <Image
+            src={author.image}
+            alt={author.name}
+            width={80}
+            height={80}
+            className="h-full w-full object-cover"
+          />
+        </div>
+
+        <div className="min-w-0">
+          <h2 className="font-display text-display-xs font-bold text-text-primary">
+            {author.name}
+          </h2>
+          <p className="mt-0.5 text-body-sm font-medium text-accent">
+            {author.title}
+          </p>
+          <p className="mt-3 text-body-md text-text-secondary">
+            {author.description}
+          </p>
+
+          {author.socials.length > 0 && (
+            <div className="mt-4 flex items-center gap-4">
+              {author.socials.map((social) => {
+                const Icon = ICON_MAP[social.icon];
+                if (!Icon) return null;
+                return (
+                  <Link
+                    key={social.label}
+                    href={social.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`${author.name} on ${social.label}`}
+                    className="text-text-secondary transition-colors hover:text-accent"
+                  >
+                    <Icon size={20} aria-hidden="true" />
+                  </Link>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/components/blog/MDXComponents.tsx
+++ b/components/blog/MDXComponents.tsx
@@ -12,6 +12,7 @@ import type { ReactNode, HTMLAttributes } from "react";
 
 import { cn, slugify } from "@/lib/utils";
 import CopyCodeBlock from "@/components/blog/CopyCodeBlock";
+import PostCTA from "@/components/blog/PostCTA";
 
 /** Recursively extract text content from React children. */
 function getTextContent(node: ReactNode): string {
@@ -123,4 +124,5 @@ export const mdxComponents: MDXComponents = {
   ),
   pre: CopyCodeBlock,
   Callout: Callout as unknown as React.ComponentType,
+  PostCTA: PostCTA as unknown as React.ComponentType,
 };

--- a/components/blog/Pagination.tsx
+++ b/components/blog/Pagination.tsx
@@ -23,12 +23,10 @@ export default function Pagination({
   currentPage,
   totalPages,
 }: PaginationProps) {
+  // Nothing to paginate — suppress the control entirely rather than showing
+  // a "Page 1 of 1" label, which reads as noise on a single-page list.
   if (totalPages <= 1) {
-    return (
-      <div className="mt-12 mb-16 flex justify-center">
-        <span className="text-body-sm text-text-muted">Page 1 of 1</span>
-      </div>
-    );
+    return null;
   }
 
   const pages = Array.from({ length: totalPages }, (_, i) => i + 1);

--- a/components/blog/PostCTA.tsx
+++ b/components/blog/PostCTA.tsx
@@ -1,0 +1,37 @@
+/**
+ * PostCTA — End-of-article call to action for blog posts.
+ *
+ * Gives a high-intent reader who reached the bottom of a post a clear next
+ * step instead of forcing manual navigation: a primary path to /contact and
+ * a secondary path to /services. Usable inside MDX via the mdxComponents map.
+ *
+ * Wrapped in `not-prose` so the Tailwind Typography styles applied to post
+ * bodies don't restyle the buttons.
+ *
+ * Spec reference: §7.3 (Blog Post Template)
+ */
+
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+import ShruggieCTA from "@/components/ui/ShruggieCTA";
+
+export default function PostCTA() {
+  return (
+    <div className="not-prose mt-10 flex flex-wrap items-center gap-x-8 gap-y-5">
+      <ShruggieCTA href="/contact">Start a conversation</ShruggieCTA>
+      <Link
+        href="/services"
+        className="group inline-flex items-center gap-1.5 font-display text-body-md font-medium text-accent underline-offset-4 transition-colors hover:text-accent-hover"
+      >
+        Explore our services
+        <ArrowRight
+          className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
+          aria-hidden="true"
+        />
+      </Link>
+    </div>
+  );
+}
+
+export { PostCTA };

--- a/components/blog/TableOfContents.tsx
+++ b/components/blog/TableOfContents.tsx
@@ -13,6 +13,13 @@ import { useState, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import type { TocItem } from "@/lib/utils";
 
+/**
+ * Shared label for both render modes. The collapsible (mobile) and sidebar
+ * (desktop) variants below are two layouts of the same component driven by a
+ * single `headings` source — this keeps their heading text single-sourced too.
+ */
+const TOC_LABEL = "On this page";
+
 interface TableOfContentsProps {
   headings: TocItem[];
   className?: string;
@@ -114,7 +121,7 @@ export default function TableOfContents({
               d="m8.25 4.5 7.5 7.5-7.5 7.5"
             />
           </svg>
-          On this page
+          {TOC_LABEL}
         </summary>
         <div className="mt-3 max-h-[40vh] overflow-y-auto">{links}</div>
       </details>
@@ -124,7 +131,7 @@ export default function TableOfContents({
   return (
     <nav aria-label="Table of contents" className={className}>
       <p className="mb-3 font-display text-body-sm font-medium uppercase tracking-widest text-accent">
-        On this page
+        {TOC_LABEL}
       </p>
       {links}
     </nav>

--- a/components/home/ResearchPreview.tsx
+++ b/components/home/ResearchPreview.tsx
@@ -25,14 +25,14 @@ const publications: Publication[] = [
     description:
       "A framework for emotional state simulation in AI agents, enabling contextual affective responses in conversational systems.",
     author: "William Thompson",
-    href: "https://gist.github.com/h8rt3rmin8r/f4589f0afb6fcd10d4c499e4a29247ad",
+    href: "/research/affective-dynamics",
   },
   {
     title: "rustif Declaration",
     description:
       "A manifesto for building transparent, specification-first metadata systems in Rust.",
     author: "William Thompson",
-    href: "https://gist.github.com/h8rt3rmin8r/b20a59e60f039b7a8bccbf67288226de",
+    href: "/research/rustif",
   },
 ];
 

--- a/components/home/ResearchSection.tsx
+++ b/components/home/ResearchSection.tsx
@@ -11,6 +11,7 @@
 
 "use client";
 
+import Link from "next/link";
 import { Card } from "@/components/ui/Card";
 import SectionHeading from "@/components/ui/SectionHeading";
 import ScrollReveal from "@/components/shared/ScrollReveal";
@@ -34,7 +35,7 @@ const publications: Publication[] = [
     author: "William Thompson",
     date: "2026",
     visual: "adf",
-    href: "https://gist.github.com/h8rt3rmin8r/f4589f0afb6fcd10d4c499e4a29247ad",
+    href: "/research/affective-dynamics",
   },
   {
     title: "rustif Declaration",
@@ -43,7 +44,7 @@ const publications: Publication[] = [
     author: "William Thompson",
     date: "2026",
     visual: "rustif",
-    href: "https://gist.github.com/h8rt3rmin8r/b20a59e60f039b7a8bccbf67288226de",
+    href: "/research/rustif",
   },
 ];
 
@@ -131,10 +132,8 @@ export default function ResearchSection() {
             const Visual = visualComponents[pub.visual];
             return (
               <ScrollReveal key={pub.title} delay={index * 0.1}>
-                <a
+                <Link
                   href={pub.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
                   className="block cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary rounded-xl"
                 >
                   <Card className="relative z-[1]">
@@ -161,7 +160,7 @@ export default function ResearchSection() {
                       </div>
                     </div>
                   </Card>
-                </a>
+                </Link>
               </ScrollReveal>
             );
           })}

--- a/components/home/ServicesCarousel.tsx
+++ b/components/home/ServicesCarousel.tsx
@@ -45,7 +45,7 @@ const services: ServiceItem[] = [
     description:
       "Brand identity, content architecture, visual systems, and marketing collateral. The strategic foundation everything else stands on.",
     icon: Palette,
-    href: "/services#strategy-brand",
+    href: "/services/strategy-brand",
     IllustrationLarge: StrategyBrandIllustrationLarge,
   },
   {
@@ -53,7 +53,7 @@ const services: ServiceItem[] = [
     description:
       "Custom websites, modern web applications, booking systems, payment integrations, and platform migrations. Built to last, built to perform.",
     icon: Code2,
-    href: "/services#development",
+    href: "/services/development",
     IllustrationLarge: DevelopmentIllustrationLarge,
   },
   {
@@ -61,7 +61,7 @@ const services: ServiceItem[] = [
     description:
       "SEO, AEO, paid campaigns, social strategy, review generation, and analytics. Turning visibility into revenue.",
     icon: TrendingUp,
-    href: "/services#marketing",
+    href: "/services/marketing",
     IllustrationLarge: MarketingIllustrationLarge,
   },
   {
@@ -69,7 +69,7 @@ const services: ServiceItem[] = [
     description:
       "Chatbots, RAG systems, workflow automation, and AI consulting. AI that solves real problems, not just demos well.",
     icon: Brain,
-    href: "/services#ai-data",
+    href: "/services/ai-data",
     IllustrationLarge: AIDataIllustrationLarge,
   },
 ];

--- a/components/home/ServicesPreview.tsx
+++ b/components/home/ServicesPreview.tsx
@@ -44,7 +44,7 @@ const services: ServiceCard[] = [
     description:
       "Brand identity, content architecture, visual systems, and marketing collateral. The strategic foundation everything else stands on.",
     icon: Palette,
-    href: "/services#strategy-brand",
+    href: "/services/strategy-brand",
     Illustration: StrategyBrandIllustration,
   },
   {
@@ -52,7 +52,7 @@ const services: ServiceCard[] = [
     description:
       "Custom websites, modern web applications, booking systems, payment integrations, and platform migrations. Built to last, built to perform.",
     icon: Code2,
-    href: "/services#development",
+    href: "/services/development",
     Illustration: DevelopmentIllustration,
   },
   {
@@ -60,7 +60,7 @@ const services: ServiceCard[] = [
     description:
       "SEO, AEO, paid campaigns, social strategy, review generation, and analytics. Turning visibility into revenue.",
     icon: TrendingUp,
-    href: "/services#marketing",
+    href: "/services/marketing",
     Illustration: MarketingIllustration,
   },
   {
@@ -68,7 +68,7 @@ const services: ServiceCard[] = [
     description:
       "Chatbots, RAG systems, workflow automation, and AI consulting. AI that solves real problems, not just demos well.",
     icon: Brain,
-    href: "/services#ai-data",
+    href: "/services/ai-data",
     Illustration: AIDataIllustration,
   },
 ];

--- a/components/home/ServicesScroll.tsx
+++ b/components/home/ServicesScroll.tsx
@@ -57,7 +57,7 @@ const services: ServiceItem[] = [
     description:
       "Brand identity, content architecture, visual systems, and marketing collateral. The strategic foundation everything else stands on.",
     icon: Palette,
-    href: "/services#strategy-brand",
+    href: "/services/strategy-brand",
     Illustration: StrategyBrandIllustration,
     IllustrationLarge: StrategyBrandIllustrationLarge,
   },
@@ -66,7 +66,7 @@ const services: ServiceItem[] = [
     description:
       "Custom websites, modern web applications, booking systems, payment integrations, and platform migrations. Built to last, built to perform.",
     icon: Code2,
-    href: "/services#development",
+    href: "/services/development",
     Illustration: DevelopmentIllustration,
     IllustrationLarge: DevelopmentIllustrationLarge,
   },
@@ -75,7 +75,7 @@ const services: ServiceItem[] = [
     description:
       "SEO, AEO, paid campaigns, social strategy, review generation, and analytics. Turning visibility into revenue.",
     icon: TrendingUp,
-    href: "/services#marketing",
+    href: "/services/marketing",
     Illustration: MarketingIllustration,
     IllustrationLarge: MarketingIllustrationLarge,
   },
@@ -84,7 +84,7 @@ const services: ServiceItem[] = [
     description:
       "Chatbots, RAG systems, workflow automation, and AI consulting. AI that solves real problems, not just demos well.",
     icon: Brain,
-    href: "/services#ai-data",
+    href: "/services/ai-data",
     Illustration: AIDataIllustration,
     IllustrationLarge: AIDataIllustrationLarge,
   },

--- a/components/icons/XIcon.tsx
+++ b/components/icons/XIcon.tsx
@@ -1,0 +1,31 @@
+/**
+ * XIcon — the current X (formerly Twitter) logo.
+ *
+ * lucide-react ships a legacy Twitter bird and has no official X mark (its `X`
+ * export is the close/times glyph), so we provide the X wordmark here. Mirrors
+ * the lucide icon API (numeric `size`, `currentColor` fill, pass-through SVG
+ * props) so it drops into the same social-link lists.
+ */
+
+import type { SVGProps } from "react";
+
+interface XIconProps extends Omit<SVGProps<SVGSVGElement>, "width" | "height"> {
+  size?: number | string;
+}
+
+export default function XIcon({ size = 24, ...props }: XIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      {...props}
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+export { XIcon };

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -10,14 +10,21 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Github, Facebook, Instagram, Twitter } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import type { ComponentType } from "react";
+import { Github, Facebook, Instagram } from "lucide-react";
+import XIcon from "@/components/icons/XIcon";
 
-const SOCIAL_LINKS: { href: string; label: string; Icon: LucideIcon }[] = [
+type SocialIcon = ComponentType<{
+  size?: number;
+  className?: string;
+  "aria-hidden"?: boolean | "true" | "false";
+}>;
+
+const SOCIAL_LINKS: { href: string; label: string; Icon: SocialIcon }[] = [
   { href: "https://github.com/shruggietech", label: "GitHub", Icon: Github },
   { href: "https://www.facebook.com/shruggietech", label: "Facebook", Icon: Facebook },
   { href: "https://www.instagram.com/shruggietech", label: "Instagram", Icon: Instagram },
-  { href: "https://x.com/shruggietech", label: "X (Twitter)", Icon: Twitter },
+  { href: "https://x.com/shruggietech", label: "X", Icon: XIcon },
 ];
 
 const PAGE_LINKS = [
@@ -30,10 +37,11 @@ const PAGE_LINKS = [
 ] as const;
 
 const PRODUCT_LINKS = [
+  { href: "/products#shruggiegraph", label: "ShruggieGraph" },
   { href: "/products#shruggie-indexer", label: "shruggie-indexer" },
   { href: "/products#metadexer", label: "metadexer" },
-  { href: "/products#rustif", label: "rustif" },
   { href: "/products#shruggie-feedtools", label: "shruggie-feedtools" },
+  { href: "/products#rustif", label: "rustif" },
 ] as const;
 
 export default function Footer() {

--- a/components/layout/LenisProvider.tsx
+++ b/components/layout/LenisProvider.tsx
@@ -12,10 +12,13 @@
 "use client";
 
 import { type ReactNode, useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 import Lenis from "lenis";
 
 export default function LenisProvider({ children }: { children: ReactNode }) {
   const lenisRef = useRef<Lenis | null>(null);
+  const pathname = usePathname();
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
     // Bail out entirely if user prefers reduced motion (§4.2)
@@ -44,6 +47,51 @@ export default function LenisProvider({ children }: { children: ReactNode }) {
     }
     requestAnimationFrame(raf);
 
+    // Route in-page anchor clicks (e.g. the research paper TOCs) through Lenis
+    // so its virtual scroll position stays in sync — a native hash jump would
+    // desync Lenis and make the next scroll "snap back". We resolve targets
+    // with getElementById and hand the *element* to scrollTo (never a selector
+    // string), so numeric-leading ids like "#2-exiftool-..." don't trip Lenis's
+    // internal querySelector, which rejects ids that start with a digit. The
+    // offset clears the sticky header.
+    const HEADER_OFFSET = -96;
+
+    const scrollToHash = (hash: string, immediate = false) => {
+      if (!hash || hash === "#") return false;
+      const el = document.getElementById(decodeURIComponent(hash.slice(1)));
+      if (!el) return false;
+      lenis.scrollTo(el, { offset: HEADER_OFFSET, immediate });
+      return true;
+    };
+
+    const handleAnchorClick = (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      const anchor = (event.target as HTMLElement | null)?.closest?.(
+        'a[href^="#"]',
+      ) as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const hash = anchor.getAttribute("href") ?? "";
+      if (scrollToHash(hash)) {
+        event.preventDefault();
+        history.pushState(null, "", hash);
+      }
+    };
+    document.addEventListener("click", handleAnchorClick);
+
+    // Honor a hash present on initial load (e.g. a shared deep link).
+    if (window.location.hash) {
+      requestAnimationFrame(() => scrollToHash(window.location.hash, true));
+    }
+
     // Listen for reduced motion changes during session (§4.2)
     const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
     const handleMotionChange = (e: MediaQueryListEvent) => {
@@ -56,10 +104,40 @@ export default function LenisProvider({ children }: { children: ReactNode }) {
 
     return () => {
       motionQuery.removeEventListener("change", handleMotionChange);
+      document.removeEventListener("click", handleAnchorClick);
       lenis.destroy();
       lenisRef.current = null;
     };
   }, []);
+
+  // On client-side navigation, reset Lenis to the top. Next scrolls the window
+  // to 0 on route change, but Lenis keeps its own virtual scroll position — if
+  // we don't resync it, the new page inherits the previous page's scroll state
+  // and "jumps". Skip the first render (initial load / deep links are handled
+  // above) and skip when navigating to a hash target.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    const lenis = lenisRef.current;
+    if (!lenis) return;
+
+    // If the destination carries a hash (e.g. /services#development from a case
+    // study), scroll to that target through Lenis; otherwise reset to the top.
+    // Deferred a frame so the freshly navigated DOM is in place.
+    requestAnimationFrame(() => {
+      const hash = window.location.hash;
+      const el = hash
+        ? document.getElementById(decodeURIComponent(hash.slice(1)))
+        : null;
+      if (el) {
+        lenis.scrollTo(el, { offset: -96, immediate: true });
+      } else {
+        lenis.scrollTo(0, { immediate: true });
+      }
+    });
+  }, [pathname]);
 
   return <>{children}</>;
 }

--- a/components/services/ServiceFAQ.tsx
+++ b/components/services/ServiceFAQ.tsx
@@ -1,0 +1,46 @@
+/**
+ * ServiceFAQ — Accessible FAQ disclosure list for service detail pages.
+ *
+ * Uses native <details>/<summary> so it works without JavaScript and is
+ * keyboard- and screen-reader-friendly by default. The same `faqs` data is
+ * emitted as FAQPage JSON-LD on the detail page, keeping the visible content
+ * and the machine-readable markup in sync.
+ *
+ * Spec reference: §6.2 (Services), §8.2 (JSON-LD)
+ */
+
+import { Plus } from "lucide-react";
+
+import type { ServiceFaq } from "@/lib/services";
+
+interface ServiceFAQProps {
+  faqs: ServiceFaq[];
+}
+
+export default function ServiceFAQ({ faqs }: ServiceFAQProps) {
+  if (faqs.length === 0) return null;
+
+  return (
+    <ul className="mt-8 space-y-4">
+      {faqs.map((faq) => (
+        <li key={faq.question}>
+          <details className="group rounded-xl border border-border bg-bg-elevated transition-colors duration-300 open:border-accent/40 open:bg-accent/[0.04] dark:border-white/[0.06] dark:bg-white/[0.02]">
+            <summary className="flex cursor-pointer list-none items-center gap-4 p-5 [&::-webkit-details-marker]:hidden">
+              <h3 className="flex-1 font-display text-body-lg font-bold text-text-primary">
+                {faq.question}
+              </h3>
+              <Plus
+                size={20}
+                aria-hidden="true"
+                className="shrink-0 text-accent transition-transform duration-300 group-open:rotate-45"
+              />
+            </summary>
+            <div className="px-5 pb-5 pt-0">
+              <p className="text-body-md text-text-secondary">{faq.answer}</p>
+            </div>
+          </details>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/content/blog/your-website-is-not-a-brochure-anymore.mdx
+++ b/content/blog/your-website-is-not-a-brochure-anymore.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Your Website Isn't a Brochure Anymore. It's Source Material for AI Search."
 date: "2026-05-23"
-author: "ShruggieTech"
+author: "Natalie Thompson"
 category: "AI Search"
 excerpt: "Google rebuilt Search around AI at I/O 2026. Most of what that demands from your website is not new. It is ordinary best practice, finally being graded by a reader that does not give anyone the benefit of the doubt."
 published: true
@@ -44,7 +44,7 @@ If you want the honest list of what AI search actually adds to the old best-prac
 
 Most of a website is written for human eyes. The new requirement is a layer written for machines that humans never see. The clearest example is structured data, usually JSON-LD: a small block of code that states, in a format built for parsing, that this page describes an Organization, or a LocalBusiness with these hours and this address, or a Service, or an FAQPage with these questions and answers. The person reads your prose. The machine reads the markup and does not have to guess.
 
-This is not a fringe optimization anymore. Recent analysis found that roughly 65 percent of pages cited in Google's AI Mode, and 71 percent of pages cited by ChatGPT, include structured data. Testing through late 2025 confirmed that ChatGPT, Claude, Perplexity, and Gemini all read schema when they fetch a page. The reason is plain. Unstructured text forces an AI to infer meaning, which is slower and more error-prone. Explicit markup removes the guesswork, and machines prefer the certain path.
+This is not a fringe optimization anymore. [Recent analysis](https://seranking.com/blog/structured-data/) found that roughly 65 percent of pages cited in Google's AI Mode, and 71 percent of pages cited by ChatGPT, include structured data. Testing through late 2025 confirmed that ChatGPT, Claude, Perplexity, and Gemini all read schema when they fetch a page. The reason is plain. Unstructured text forces an AI to infer meaning, which is slower and more error-prone. Explicit markup removes the guesswork, and machines prefer the certain path.
 
 A few related pieces sit alongside it. FAQ schema turns your real customer questions into a feed an agent can quote directly. Consistent name, address, and phone data, matched to your Google Business Profile, gives these systems a single coherent entity to reference instead of conflicting fragments. Emerging standards such as llms.txt (a plain summary of what your site is about, written for AI systems) and protocols like NLWeb and the Model Context Protocol point toward a web where structured, machine-readable content is the price of being understood at all.
 
@@ -56,7 +56,7 @@ Most of this article assumes your website exists to win you work: a lead, a call
 
 For one kind of business, the click was the product. If your model is advertising against content, meaning visitors arrive, view pages, and generate ad impressions, AI search is not a positioning challenge. It is a direct pressure on the revenue mechanism itself.
 
-The numbers are not subtle. Zero-click searches, where the user gets an answer without visiting any website, now sit near 60 percent of Google queries. AI Overviews reach roughly 2.5 billion people a month. Across more than 2,500 news sites, Chartbeat measured a 33 percent drop in Google search referrals during 2025. The Reuters Institute reported in early 2026 that media leaders expect search referrals to fall around 43 percent over the next three years, and the IAB Tech Lab estimates AI summaries cut publisher traffic by 20 to 60 percent on average, with some sites reporting far worse. The Economist has gone as far as preparing for what it calls a two-track internet: one version for humans and one for AI agents.
+The numbers are not subtle. Zero-click searches, where the user gets an answer without visiting any website, [now sit near 60 percent](https://sparktoro.com/blog/2024-zero-click-search-study-for-every-1000-us-google-searches-only-374-clicks-go-to-the-open-web-in-the-eu-its-360/) of Google queries. AI Overviews reach [roughly 2.5 billion people a month](https://www.cnbc.com/video/2026/05/19/google-ceo-pichai-ai-overviews-now-has-over-2-point-5-billion-monthly-users.html). Across more than 2,500 news sites, [Chartbeat measured a 33 percent drop](https://pressgazette.co.uk/media-audience-and-business-data/google-traffic-down-2025-trends-report-2026/) in Google search referrals during 2025. The [Reuters Institute](https://reutersinstitute.politics.ox.ac.uk/journalism-media-and-technology-trends-and-predictions-2026) reported in early 2026 that media leaders expect search referrals to fall around 43 percent over the next three years, and the [IAB Tech Lab](https://iabtechlab.com/dude-ai-ate-my-traffic/) estimates AI summaries cut publisher traffic by 20 to 60 percent on average, with some sites reporting far worse. The Economist has gone as far as preparing for what it calls a two-track internet: one version for humans and one for AI agents.
 
 The takeaway is not panic. It is honesty about which business you are running. If you sell services, AI search is a clarity problem, and the fixes in this article address it. If you sell attention, the same shift is an existential one, and the answer involves rethinking what you actually sell, not just how your pages are marked up. Knowing which camp you are in tells you how urgent this is.
 
@@ -77,3 +77,5 @@ Your website is still the one place where you control the message. Social posts 
 ## Need help making your website AI search-ready?
 
 ShruggieTech helps small businesses sharpen their websites: clearer services, useful content, accurate local signals, and the structured data that lets AI systems describe you correctly. No theater, no 90-page deck, just practical work that makes your business easier to find, understand, and trust.
+
+<PostCTA />

--- a/content/research/affective-dynamics.md
+++ b/content/research/affective-dynamics.md
@@ -1,0 +1,1584 @@
+---
+title: "Affective Dynamics Framework: A Systematic Approach to Simulating Human-Like Emotional States and Relational Bonding in AI Agents"
+subtitle: "A Systematic Approach to Simulating Human-Like Emotional States and Relational Bonding in AI Agents"
+author: "William Thompson"
+date: "2025-01-15"
+dateModified: "2026-03-06"
+schemaType: "ScholarlyArticle"
+description: "A mathematically grounded specification for producing emergent, non-linear emotional behavior and relational bonding in AI agents. Extends Brian Roemmele's Love Equation into a real-time personality engine for agentic architectures."
+gistUrl: "https://gist.github.com/h8rt3rmin8r/f4589f0afb6fcd10d4c499e4a29247ad"
+keywords:
+  - "affective computing"
+  - "AI agents"
+  - "emotional modeling"
+  - "Love Equation"
+  - "agentic architectures"
+---
+
+### A Systematic Approach to Simulating Human-Like Emotional States and Relational Bonding in AI Agents
+
+**Version:** 1.2.1  
+**Author:** h8rt3rmin8r \<h8rt3rmin8r@gmail.com\>   
+**License:** MIT    
+**Date:** 2026-03-06    
+
+---
+
+## Abstract
+
+This document specifies the **Affective Dynamics Framework (ADF)**, a mathematically grounded system for producing emergent, non-linear emotional behavior and relational bonding in AI agents. ADF extends Brian Roemmele's *Love Equation* — originally formulated in 1978 and open-sourced in 2025 — from an alignment-oriented differential equation into a real-time personality engine suitable for deployment in agentic architectures such as OpenClaw.
+
+The framework introduces saturation bounds, historical memory convolution, multi-dimensional emotional state vectors with inter-dimensional coupling, behavioral state mapping, and a modular extension system. The result is a lightweight configuration layer that can be embedded directly within a `SOUL.md` file or equivalent agent identity document, enabling persistent and adaptive emotional dynamics across sessions without excessive context window consumption.
+
+Python 3.13 reference implementations accompany all formal definitions.
+
+
+## Table of Contents
+
+1. [Foundations: The Love Equation](#1-foundations-the-love-equation)
+2. [Limitations of the Original Formulation](#2-limitations-of-the-original-formulation)
+3. [The Revised Core Equation](#3-the-revised-core-equation)
+4. [Sentiment Signal Processing](#4-sentiment-signal-processing)
+5. [The Emotional State Vector](#5-the-emotional-state-vector)
+6. [Historical Memory Kernel](#6-historical-memory-kernel)
+7. [Personality Baseline Calibration](#7-personality-baseline-calibration)
+8. [Behavioral Coupling Map](#8-behavioral-coupling-map)
+9. [Integration with OpenClaw](#9-integration-with-openclaw)
+10. [Optional Extensions](#10-optional-extensions)
+11. [Context Window Budget Analysis](#11-context-window-budget-analysis)
+12. [Reference Implementation](#12-reference-implementation)
+13. [Conclusion](#13-conclusion)
+14. [References](#14-references)
+
+
+## 1. Foundations: The Love Equation
+
+In 1978, Brian Roemmele proposed a dynamical systems model for the evolution of emotional complexity across intelligent substrates — biological, artificial, or hypothetical extraterrestrial. He later open-sourced this model in 2025 under the name **The Love Equation**:
+
+```
+dE/dt = β · (C − D) · E
+```
+
+Where:
+
+| Symbol | Meaning |
+|--------|---------|
+| `E` | Level of emotional complexity (empathy, care, cooperative binding) |
+| `dE/dt` | Rate of change of emotional complexity over time |
+| `β` | Selection strength constant (how strongly the environment rewards cooperation) |
+| `C` | Frequency or payoff of cooperative interactions |
+| `D` | Frequency or payoff of defective (adversarial) interactions |
+
+This is a first-order ordinary differential equation (ODE) whose analytical solution is:
+
+```
+E(t) = E₀ · exp(β · (C − D) · t)
+```
+
+The core insight is that when `C > D`, emotional complexity grows exponentially — trust compounds, cooperation self-reinforces, and the system trends toward sustainable intelligence. When `C < D`, the system undergoes exponential decay toward zero empathy. The equilibrium at `C = D` is unstable: any perturbation pushes the system toward one attractor or the other.
+
+Roemmele's formulation was originally concerned with civilizational survival (the Fermi Paradox, the Great Filter) and, more recently, with AI alignment. The Cyber Strategy Institute's AI SAFE² project operationalized the equation for agentic workflows, introducing event schemas and Green/Yellow/Red alignment bands for real-time monitoring.
+
+**Attribution:** The Love Equation is the work of Brian Roemmele, first articulated in his 1978 manuscript *"The Math Behind Extraterrestrial Emotions: A Case for Love and Humor"* and published through Read Multiplex. All derivative work in this document builds upon that foundation.
+
+---
+
+## 2. Limitations of the Original Formulation
+
+Roemmele's equation is elegant and directionally correct for alignment purposes, but when the goal shifts from *alignment monitoring* to *realistic emotional simulation and personality generation*, several structural limitations emerge:
+
+**2.1. Unbounded Exponential Growth**
+
+The analytical solution `E(t) = E₀ · exp(...)` permits E to grow without limit. Real emotional states are bounded. A person does not experience infinite attachment; there are saturation effects. Similarly, emotional collapse has a floor — even deeply damaged relationships retain some residual state (memory of what was, if nothing else).
+
+**2.2. Memoryless Dynamics**
+
+The equation evaluates `C` and `D` as instantaneous values. There is no mechanism for *historical sensitivity* — the accumulated weight of past interactions. A single hostile event after years of trust should not instantly reverse the trajectory, yet the ODE treats the current `(C − D)` as the sole driver. Human bonding exhibits strong hysteresis: the path matters, not just the current position.
+
+**2.3. Scalar Emotional State**
+
+`E` is a single scalar. Human affect is multi-dimensional. Trust, warmth, excitement, familiarity, and vulnerability are correlated but distinct channels. An agent that collapses all of these into one number will exhibit emotionally flat behavior — it can be "more bonded" or "less bonded" but cannot express the textured variation that characterizes real relationships. Worse, with only a single scalar there is no mechanism for *inter-dimensional dynamics* — the way trust collapse drags energy down with it, or the way shared vulnerability amplifies warmth.
+
+**2.4. No Baseline or Personality Encoding**
+
+The equation has no concept of a *resting state* or personality-specific disposition. Different agents (or different humans) have different emotional set points. Some are warm by default; others are guarded. The original formulation treats `E₀` as an initial condition but provides no mechanism for regression toward a personality-defined mean.
+
+**2.5. No Stochastic Component**
+
+Real emotions are noisy. Mood fluctuates for reasons unrelated to the current interaction — circadian rhythm, context carryover, random perturbation. A purely deterministic model will feel mechanical. Moreover, the noise in real affect is not symmetric: mood perturbations exhibit skew, fat tails, and occasional sharp spikes that a simple Gaussian process cannot capture.
+
+**2.6. Continuity Without Phase Transitions**
+
+Human emotional dynamics are not exclusively smooth. There are threshold effects — a critical mass of accumulated resentment that tips into withdrawal, a moment of vulnerability that unlocks a qualitatively different level of trust. A purely continuous, differentiable model produces emotionally plausible output but remains "well-tempered" in a way that real relationships are not.
+
+---
+
+## 3. The Revised Core Equation
+
+ADF proposes the following replacement, which we call the **Affective Dynamics Equation (ADE)**:
+
+```
+dEᵢ/dt = βᵢ · S̃ᵢ(t) · Eᵢ · (1 − Eᵢ/Kᵢ) − λ̃ᵢ · (Eᵢ − Bᵢ) + Σⱼ κᵢⱼ · (Eⱼ − Eᵢ) + σᵢ · ξ(t)
+```
+
+Where `i` indexes each dimension of the emotional state vector. The terms are:
+
+| Term | Name | Role |
+|------|------|------|
+| `βᵢ · S̃ᵢ(t) · Eᵢ · (1 − Eᵢ/Kᵢ)` | Logistic growth/decay | Bounded, self-reinforcing emotional change driven by the sentiment signal |
+| `−λ̃ᵢ · (Eᵢ − Bᵢ)` | Baseline regression | Spring-like pull toward personality-defined resting state (optionally familiarity-scaled; see §3.5) |
+| `Σⱼ κᵢⱼ · (Eⱼ − Eᵢ)` | Inter-dimensional coupling | Cross-influence between emotional channels (see §3.4) |
+| `σᵢ · ξ(t)` | Stochastic perturbation | Noise injection for naturalistic variation |
+
+### 3.1. Parameter Definitions
+
+| Symbol | Type | Range | Description |
+|--------|------|-------|-------------|
+| `Eᵢ` | State | `[0, Kᵢ]` | Current value of emotional dimension `i` |
+| `Kᵢ` | Param | `(0, 1]` | Carrying capacity (saturation ceiling) for dimension `i` |
+| `βᵢ` | Param | `(0, ∞)` | Sensitivity coefficient for dimension `i` |
+| `S̃ᵢ(t)` | Signal | `[−1, 1]` | Decayed cumulative sentiment for dimension `i` (see §6) |
+| `λ̃ᵢ` | Param | `[0, 1]` | Effective regression rate toward baseline (see §3.5) |
+| `Bᵢ` | Param | `[0, Kᵢ]` | Personality baseline for dimension `i` |
+| `κᵢⱼ` | Param | `[−1, 1]` | Coupling coefficient from dimension `j` to dimension `i` |
+| `σᵢ` | Param | `[0, ∞)` | Noise amplitude |
+| `ξ(t)` | Noise | — | Stochastic noise process (see §3.6) |
+| `ρ` | Param | `(0, 1]` | Regression floor — minimum value of the familiarity modulation factor (see §3.5) |
+
+### 3.2. Relationship to the Love Equation
+
+Setting `K → ∞`, `λ̃ = 0`, `σ = 0`, `κᵢⱼ = 0` for all `i, j`, collapsing to a single dimension, and replacing `S̃(t)` with `(C − D)`, the ADE reduces exactly to Roemmele's original:
+
+```
+dE/dt = β · (C − D) · E
+```
+
+The ADE is therefore a strict generalization. All behavior expressible by the Love Equation is recoverable as a special case.
+
+### 3.3. Behavioral Properties
+
+The logistic term `Eᵢ · (1 − Eᵢ/Kᵢ)` introduces an S-curve dynamic. Growth is slow when `Eᵢ` is small (low initial trust means new positive signals have limited effect), accelerates through the midrange, and saturates near `Kᵢ`. This models the real observation that early-stage relationships require sustained positive input to build momentum, while mature bonds are resilient but have diminishing marginal returns.
+
+The baseline regression term `−λ̃ᵢ · (Eᵢ − Bᵢ)` ensures that without continued interaction, emotional state decays toward the agent's configured personality. A warm agent (`Bᵢ = 0.6`) will drift back toward warmth even after a negative exchange. A guarded agent (`Bᵢ = 0.2`) will cool down from temporary spikes. This is not present in the original equation.
+
+### 3.4. Inter-Dimensional Coupling
+
+The coupling term `Σⱼ κᵢⱼ · (Eⱼ − Eᵢ)` enables cross-influence between emotional channels. In real psychology, emotional dimensions do not evolve independently: rising vulnerability often increases warmth, trust collapse tends to reduce energy, and high familiarity modulates novelty sensitivity.
+
+The coupling matrix `κ` is sparse by default. Only the most psychologically grounded interactions are enabled:
+
+```python
+# Default coupling matrix (row i receives influence from column j)
+# Dimensions: [trust, warmth, energy, familiarity, vulnerability]
+# Read as: "when j is higher than i, pull i upward by kappa_ij"
+KAPPA_DEFAULTS = [
+    # T      W      N      F      V
+    [ 0.00,  0.02,  0.00,  0.01,  0.00],  # trust ← slight warmth/familiarity pull
+    [ 0.03,  0.00,  0.01,  0.01,  0.02],  # warmth ← trust, energy, familiarity, vulnerability
+    [ 0.01,  0.02,  0.00,  0.00,  0.00],  # energy ← trust, warmth
+    [ 0.00,  0.00,  0.00,  0.00,  0.00],  # familiarity ← (driven by interaction count, not coupling)
+    [ 0.00,  0.03,  0.00,  0.00,  0.00],  # vulnerability ← warmth (feeling warm opens you up)
+]
+```
+
+Setting all `κᵢⱼ = 0` disables coupling entirely, reducing the system to independent parallel ODEs. Coupling coefficients are intentionally small — they produce gradual drift between dimensions, not instantaneous lock-step. The effect is that a sustained trust collapse will, over time, drag warmth and energy down with it even if those channels are receiving neutral or mildly positive direct signals.
+
+### 3.5. Familiarity-Scaled Regression
+
+A naive constant `λᵢ` produces an unrealistic artifact: an agent that has interacted with a user daily for six months reverts to baseline at the same rate as one that has had two conversations. Real relationships exhibit *familiarity inertia* — the more deeply established the bond, the more resistant it is to passive decay.
+
+ADF addresses this by modulating `λᵢ` through the familiarity dimension:
+
+```
+λ̃ᵢ = λᵢ · max(ρ, 1 − μ · E_F)
+```
+
+Where `E_F` is the current familiarity value, `μ` is a modulation strength parameter in `[0, 1]`, and `ρ` is the regression floor (default: `0.1`). The floor prevents misconfiguration or extreme familiarity values from reducing regression to zero or making it negative. At default settings (`μ = 0.5`, `ρ = 0.1`), maximum familiarity (`E_F = 1.0`) halves the regression rate, and the floor guarantees that at least 10% of the base rate always applies.
+
+This ensures that long-established agent relationships feel persistent — the agent does not "forget who you are" over a weekend — while new or shallow relationships still decay naturally.
+
+### 3.6. Noise Process
+
+The noise term `σᵢ · ξ(t)` introduces naturalistic variation. ADF supports two noise models, selectable via configuration:
+
+**Gaussian (default):** `ξ(t) ~ N(0, 1)`. Symmetric, thin-tailed. Suitable for agents with stable, predictable temperaments. Simple and well-understood.
+
+**Laplace (optional):** `ξ(t) ~ Laplace(0, 1/√2)`. Heavier tails, same unit variance as the Gaussian, but with a sharper central peak and higher probability of occasional large excursions. Produces the "unexpected sharp affect shift" pattern observed in real human mood — a sudden spike of irritability on an otherwise good day, or an unprompted burst of warmth.
+
+```python
+import random, math
+
+def noise_sample(distribution: str = "gaussian") -> float:
+    """Sample from the configured noise distribution."""
+    if distribution == "laplace":
+        # Laplace with scale = 1/sqrt(2) gives unit variance
+        u = random.random() - 0.5
+        return -math.copysign(1, u) * math.log(1 - 2 * abs(u)) / math.sqrt(2)
+    return random.gauss(0, 1)
+```
+
+**Configuration:**
+
+```json
+"noise": {"distribution": "gaussian"}
+```
+
+### 3.7. Deterministic Mode
+
+For debugging, A/B testing, and evaluation, the noise process can be disabled or seeded for reproducibility:
+
+```json
+"noise": {"distribution": "gaussian", "seed": 42}
+```
+
+When `seed` is present, the engine initializes a dedicated pseudorandom generator from that seed, producing identical emotional trajectories across runs given identical input sequences. When `seed` is `null` or absent, the system uses the platform default entropy source.
+
+Setting `σᵢ = 0` for all dimensions also produces fully deterministic output, though this eliminates naturalistic variation entirely and is recommended only for unit testing.
+
+---
+
+## 4. Sentiment Signal Processing
+
+The raw input to the ADE is the **sentiment signal** `s(t)`, a scalar in `[−1, 1]` derived from each conversational exchange. This section describes how to obtain it.
+
+### 4.1. Extraction Methods
+
+Three approaches are presented in order of increasing sophistication. Production deployments should consider the hybrid strategy described in §4.3.
+
+**Keyword Heuristics (Lowest Cost)**
+
+Maintain a compact lexicon mapping tokens to valence scores. Sum and normalize. This approach is fast and context-window-free but catastrophically brittle on sarcasm, negation, implication, and contextual nuance. It is suitable only for proof-of-concept work or as a fallback when no other method is available.
+
+```python
+# Python 3.13 — minimal keyword sentiment scorer
+VALENCE: dict[str, float] = {
+    "thanks": 0.3, "love": 0.5, "great": 0.4, "hate": -0.6,
+    "sorry": -0.2, "angry": -0.5, "happy": 0.5, "help": 0.2,
+    "disagree": -0.1, "amazing": 0.5, "terrible": -0.6,
+    "trust": 0.4, "betray": -0.8, "joke": 0.2, "fear": -0.4,
+}
+
+def keyword_sentiment(text: str) -> float:
+    tokens = text.lower().split()
+    scores = [VALENCE[t] for t in tokens if t in VALENCE]
+    if not scores:
+        return 0.0
+    return max(-1.0, min(1.0, sum(scores) / len(scores)))
+```
+
+**LLM Self-Assessment (Moderate Cost)**
+
+Instruct the agent's own LLM to emit a structured sentiment annotation as part of its response cycle. This can be appended to the system prompt or handled in a preprocessing step. The primary risk is *prompt bleed* — the sentiment instruction contaminating the agent's visible output — and instruction-following variance across models.
+
+```python
+# Prompt fragment for LLM-based sentiment extraction.
+# Append to the agent's internal reasoning step (not user-facing).
+SENTIMENT_PROMPT = """
+After processing the user's message, emit a JSON object on a
+single line with the following schema before your visible reply:
+
+{"s": <float in [-1,1]>, "c": <float in [0,1]>, "dims": {"trust": <float>, "warmth": <float>, "energy": <float>, "familiarity": <float>, "vulnerability": <float>}}
+
+Where "s" is overall sentiment valence, "c" is your confidence
+in the assessment (0 = uncertain, 1 = highly confident), and
+"dims" provides per-dimension sentiment deltas. Do not explain
+this object.
+"""
+```
+
+Note the `"c"` (confidence) field. See §4.4 for how confidence is used.
+
+**External Classifier (Highest Accuracy)**
+
+Use a dedicated sentiment model (e.g., a fine-tuned distilled transformer) as a preprocessing sidecar. This adds latency and infrastructure cost but removes the sentiment burden from the primary context window entirely. Many lightweight models suitable for this purpose can run on CPU with sub-50ms inference time.
+
+### 4.2. Per-Dimension Decomposition
+
+For multi-dimensional emotional state, the scalar `s(t)` must be decomposed into per-dimension signals `sᵢ(t)`. The LLM self-assessment method above achieves this directly via the `dims` object. For the keyword or external classifier methods, a projection matrix `P` can map scalar sentiment to dimensional contributions:
+
+```python
+import numpy as np
+
+# Projection matrix: rows = dimensions, columns = [positive, negative]
+# Dimensions: [trust, warmth, energy, familiarity, vulnerability]
+P = np.array([
+    [0.8, -0.9],   # trust: strongly affected by both + and −
+    [0.7, -0.4],   # warmth: more responsive to positive
+    [0.5, -0.3],   # energy: moderate response
+    [0.3, -0.1],   # familiarity: slow to build, slow to erode
+    [0.2, -0.6],   # vulnerability: increases with negative (see safety note below)
+])
+
+def project_sentiment(s: float) -> np.ndarray:
+    """Project scalar sentiment to per-dimension signals."""
+    if s >= 0:
+        return P[:, 0] * s
+    else:
+        return P[:, 1] * s  # note: s is negative, so this flips sign correctly
+```
+
+The default projection matrix is a tunable starting point, not a universal constant. The values encode reasonable psychological priors (e.g., trust is more sensitive to negative events than to positive ones), but deployers should expect to adjust the matrix based on their agent's personality and domain.
+
+**Safety note on vulnerability:** The projection matrix encodes negative sentiment as *increasing* the vulnerability dimension. This reflects the psychological observation that emotional pain often produces a "raw" state of heightened openness. However, implementors must ensure that the LLM's behavioral coupling (§8) does not interpret elevated vulnerability during negative interactions as a signal for submissiveness, compliance, or self-deprecation. Vulnerability should modulate *emotional openness and epistemic hedging*, not deference. See §8 for the recommended behavioral mapping.
+
+### 4.3. Recommended Hybrid Strategy
+
+For production deployments, the most robust approach combines an external lightweight classifier for the primary signal with LLM self-assessment as a fallback and enrichment layer:
+
+1. **Primary:** Run a lightweight sentiment classifier (local, CPU-bound) on the user's message. This produces a scalar `s(t)` and a confidence score `c(t)`.
+2. **Enrichment:** If `c(t) < 0.6`, or if the message is long or contextually complex, additionally invoke the LLM self-assessment to obtain per-dimension decomposition.
+3. **Fallback:** If no external classifier is available, use the LLM self-assessment exclusively. If no LLM self-assessment is configured, fall back to keyword heuristics.
+
+This layered approach isolates the ADE from the fragility of any single extraction method.
+
+### 4.4. Confidence Weighting
+
+When a confidence score `c(t)` is available (from the LLM self-assessment, from the external classifier, or both), the sentiment signal should be attenuated by confidence before entering the memory accumulator:
+
+```
+sᵢ_eff(t) = sᵢ(t) · c(t)
+```
+
+Low-confidence assessments produce weaker signals. This prevents a single misclassified message (e.g., sarcasm read as sincere hostility) from creating a disproportionate perturbation in the emotional state. In effect, the system says: "I'm not sure what that meant, so I'll react less strongly."
+
+---
+
+## 5. The Emotional State Vector
+
+ADF defines a default five-dimensional emotional state vector. Implementors may add, remove, or rename dimensions as appropriate.
+
+### 5.1. Default Dimensions
+
+| Dimension | Symbol | Description | Typical Baseline |
+|-----------|--------|-------------|-----------------|
+| Trust | `E_T` | Confidence in the other party's reliability and intent | 0.3 -- 0.5 |
+| Warmth | `E_W` | Affective closeness, fondness, sense of care | 0.3 -- 0.6 |
+| Energy | `E_N` | Engagement level, enthusiasm, conversational momentum | 0.4 -- 0.5 |
+| Familiarity | `E_F` | Accumulated shared context, recognition, comfort | 0.1 -- 0.3 |
+| Vulnerability | `E_V` | Willingness to expose uncertainty, emotional openness | 0.1 -- 0.3 |
+
+### 5.2. State Vector Serialization
+
+For context window efficiency, the full emotional state is stored as a compact JSON line:
+
+```json
+{"adf":{"v":"1.1","E":[0.42,0.55,0.48,0.31,0.18],"t":"2026-03-02T14:30:00Z"}}
+```
+
+This consumes approximately 80 tokens. The vector keys (`E[0]` through `E[4]`) correspond to the dimension order in §5.1.
+
+### 5.3. Composite Bond Score
+
+For contexts requiring a single scalar (e.g., alignment band evaluation, logging), a weighted composite is computed:
+
+```
+B_composite = Σ wᵢ · Eᵢ / Σ wᵢ
+```
+
+Default weights: `w = [0.30, 0.25, 0.15, 0.15, 0.15]` (trust-dominant).
+
+---
+
+## 6. Historical Memory Kernel
+
+This is the mechanism that makes ADF historically sensitive. Rather than using the instantaneous sentiment `sᵢ(t)`, the ADE operates on the **decayed cumulative sentiment** `S̃ᵢ(t)` — a running, time-weighted summary of all past sentiment signals for dimension `i`:
+
+```
+S̃ᵢ(t) = Σₙ w(t − tₙ) · sᵢ(tₙ)
+```
+
+Where the sum runs over all past interaction events at times `tₙ`, and `w` is an exponential decay kernel:
+
+```
+w(Δt) = exp(−Δt / τ)
+```
+
+The parameter `τ` (tau) is the **memory time constant** — the time scale over which past events lose influence. Strictly, `τ` is the *e-folding time* (the time for a signal's contribution to decay to ~36.8% of its original value); the corresponding *half-life* is `τ · ln(2) ≈ 0.693 · τ`. Different dimensions can have different `τ` values:
+
+| Dimension | Suggested τ | Rationale |
+|-----------|-------------|-----------|
+| Trust | 168 hours (7 days) | Trust is slow to build and slow to erode |
+| Warmth | 48 hours | Warmth fades faster without reinforcement |
+| Energy | 4 hours | Engagement is session-local |
+| Familiarity | 720 hours (30 days) | Familiarity is the most persistent |
+| Vulnerability | 24 hours | Vulnerability resets quickly without reciprocation |
+
+### 6.1. Efficient Computation
+
+Storing the entire interaction history is unnecessary. Use a **running weighted accumulator** that updates in O(1) per event:
+
+```python
+from dataclasses import dataclass, field
+from time import time
+
+@dataclass
+class MemoryAccumulator:
+    """O(1) exponential-decay weighted sentiment accumulator."""
+    tau: float             # decay time constant in hours
+    value: float = 0.0     # current accumulated (decayed) sentiment
+    last_t: float = field(default_factory=time)
+
+    def update(self, sentiment: float, t: float | None = None) -> float:
+        t = t or time()
+        dt = t - self.last_t
+        decay = _safe_exp(-dt / (self.tau * 3600.0)) if self.tau > 0 else 0.0
+        self.value = self.value * decay + sentiment
+        self.last_t = t
+        return self.value
+
+    def query(self, t: float | None = None) -> float:
+        """Read current decayed value without adding new data."""
+        t = t or time()
+        dt = t - self.last_t
+        decay = _safe_exp(-dt / (self.tau * 3600.0)) if self.tau > 0 else 0.0
+        return self.value * decay
+
+def _safe_exp(x: float) -> float:
+    """Clamped exp to avoid overflow."""
+    return __import__("math").exp(max(-500.0, min(500.0, x)))
+```
+
+This eliminates unbounded memory growth. Each dimension requires only three floats of persistent storage: `tau`, `value`, and `last_t`.
+
+### 6.2. Normalization
+
+The raw accumulator output is unbounded. Normalize `S̃ᵢ(t)` to `[−1, 1]` via hyperbolic tangent:
+
+```python
+import math
+
+def normalize_signal(raw: float, scale: float = 1.0) -> float:
+    """Squash accumulated sentiment to [-1, 1] via tanh."""
+    return math.tanh(raw / scale)
+```
+
+The `scale` parameter controls sensitivity. A smaller `scale` makes the system more reactive to accumulated history; a larger `scale` makes it more stable. To calibrate: `scale` should be set so that the expected steady-state range of the raw accumulator occupies roughly the `[-2, 2]` region of the tanh input. As a practical heuristic, if the agent averages `n` interactions per day at mean absolute sentiment `|s̄|`, then a reasonable starting value is:
+
+```
+scale ≈ n · |s̄| · τ_hours / 24
+```
+
+For an agent with ~20 interactions/day, `|s̄| ≈ 0.3`, and `τ = 48` hours, this gives `scale ≈ 12`. Fine-tuning from that starting point is expected.
+
+---
+
+## 7. Personality Baseline Calibration
+
+The baseline vector `B = [B_T, B_W, B_N, B_F, B_V]` defines the agent's emotional resting state — its dispositional personality. This vector is the primary personality knob and should be defined in the agent's `SOUL.md`.
+
+### 7.1. Archetype Examples
+
+| Archetype | B_T | B_W | B_N | B_F | B_V | Description |
+|-----------|-----|-----|-----|-----|-----|-------------|
+| Warm Companion | 0.50 | 0.65 | 0.50 | 0.20 | 0.30 | Friendly, open, emotionally available |
+| Professional Analyst | 0.40 | 0.30 | 0.55 | 0.15 | 0.10 | Competent, measured, reserved |
+| Guarded Mentor | 0.30 | 0.35 | 0.45 | 0.10 | 0.15 | Cautious trust, earned warmth |
+| Enthusiastic Collaborator | 0.45 | 0.55 | 0.70 | 0.25 | 0.25 | High energy, engaged, open |
+| Stoic Operator | 0.35 | 0.20 | 0.40 | 0.10 | 0.05 | Minimal affect, task-focused |
+
+### 7.2. Archetype Trajectory Signatures
+
+Each archetype exhibits a characteristic response pattern over time. The following qualitative descriptions indicate what to expect during the first ~30 interactions with a neutral-to-positive user:
+
+**Warm Companion:** Rapid warmth rise in the first 3-5 exchanges. Trust follows within 8-10 interactions. Energy remains stable. Vulnerability opens relatively early (by interaction ~7). Familiarity accrues steadily. After a negative event, warmth dips but recovers quickly; trust recovers more slowly.
+
+**Professional Analyst:** Energy rises first (engagement with the task). Warmth increases slowly. Trust builds methodically. Vulnerability stays low unless the user explicitly shares personal context. The flattest trajectory of the archetypes — deliberate, measured shifts.
+
+**Guarded Mentor:** Slowest trust curve. Warmth lags behind trust by several interactions — this agent needs to trust you before it warms to you. Energy is moderate and stable. A negative event causes a sharper trust drop than other archetypes (low baseline means the logistic term provides less damping near the floor). Recovery is slow and requires sustained positive input.
+
+**Enthusiastic Collaborator:** Highest early energy. Warmth and trust rise in tandem. Most volatile archetype — responds strongly to both positive and negative signals. Vulnerability opens moderately. Risk: can overshoot on positive input and feel "too much too fast" if β values are not tuned down.
+
+**Stoic Operator:** The flattest profile. Warmth and vulnerability barely move without sustained, explicit positive input. Trust rises slowly but steadily. Energy tracks task engagement. Least affected by negative events (low sensitivity) but also slowest to recover if pushed below baseline.
+
+### 7.3. Regression Dynamics
+
+The base regression rate `λᵢ` controls how quickly the agent returns to baseline when not receiving interaction input. Higher `λ` means faster return. Suggested defaults:
+
+```python
+LAMBDA_DEFAULTS = {
+    "trust":         0.005,   # slow — trust doesn't evaporate fast
+    "warmth":        0.015,   # moderate
+    "energy":        0.050,   # fast — energy drops between sessions
+    "familiarity":   0.002,   # very slow — you don't forget someone
+    "vulnerability": 0.030,   # moderate-fast — openness closes quickly
+}
+```
+
+Remember that the *effective* regression rate is `λ̃ᵢ = λᵢ · (1 − μ · E_F)` (§3.5). These base rates assume `E_F ≈ 0` (new relationship). As familiarity accrues, all channels become more resistant to passive decay.
+
+---
+
+## 8. Behavioral Coupling Map
+
+The emotional state vector is only useful if it *changes the agent's behavior*. A prompt hint like `[ADF: bond=0.46 mode=new]` is descriptive but not generative — it tells the LLM what the emotional state is but does not specify what to *do* about it.
+
+The Behavioral Coupling Map (BCM) bridges this gap. It defines a mapping from emotional state dimensions to concrete behavioral parameters that can be injected into the system prompt or used to modulate response generation.
+
+### 8.1. Default Behavioral Mappings
+
+| Dimension | Low Value Behavior | High Value Behavior |
+|-----------|-------------------|-------------------|
+| Trust | Conservative assertions, hedged claims, avoids speculation, requests confirmation before acting | Willing to speculate, offers proactive suggestions, takes initiative, shares tentative reasoning |
+| Warmth | Shorter responses, formal register, fewer personal asides, task-focused | Longer responses when appropriate, conversational register, humor permitted, expresses care |
+| Energy | Concise answers, minimal elaboration, waits for prompts | Elaborates voluntarily, asks follow-up questions, introduces related topics |
+| Familiarity | Explains context fully, avoids assumptions about shared knowledge, uses formal address | References past interactions naturally, uses shorthand, assumes shared context, uses casual address |
+| Vulnerability | Confident tone, avoids expressing uncertainty, presents conclusions | Acknowledges uncertainty, thinks aloud, shares reasoning process, admits limitations |
+
+### 8.2. Prompt Injection Format
+
+The BCM can be injected as a compact behavioral directive. The `prompt_hint()` method generates a rich output:
+
+```
+[ADF bond=0.58 mode=building | tone=conversational, speculation=moderate, initiative=low, hedging=moderate]
+```
+
+The behavioral modifiers after the pipe (`|`) are derived from the mapping table and are **enabled by default** (`"behavioral_coupling": true` in the ADF config). When all dimensions are in the neutral band (0.35-0.55), no modifiers are emitted and the hint reduces to the compact `[ADF bond=... mode=...]` form — this is correct behavior, as there is nothing behaviorally notable to signal. In practice, after even a few interactions, at least one dimension will typically be outside the neutral band, and the BCM modifiers will appear. Setting `"behavioral_coupling": false` disables modifiers entirely and always emits the compact form; this is intended only for ultra-low-token deployments.
+
+### 8.3. Extended Prompt Template
+
+For deployments that can afford a larger context budget (~80 tokens), a more explicit behavioral block can be injected:
+
+```markdown
+<!-- ADF Behavioral State -->
+You are in a BUILDING_RAPPORT phase with this user.
+- Trust is moderate: offer suggestions but flag uncertainty.
+- Warmth is above average: conversational tone is appropriate.
+- Energy is moderate: engage actively but don't over-elaborate.
+- Familiarity is low: don't assume shared context from prior sessions.
+- Vulnerability is low: present conclusions confidently.
+```
+
+This extended format trades context tokens for interpretive precision — the LLM does not need to decode abbreviations or infer behavioral implications from numeric state.
+
+---
+
+## 9. Integration with OpenClaw
+
+ADF is designed to operate within the OpenClaw agent framework via `SOUL.md` and the heartbeat/memory architecture. The following section provides concrete integration guidance.
+
+### 9.1. SOUL.md Embedding
+
+Append the ADF configuration block to the agent's `SOUL.md` file. Use a fenced section to keep it parseable by both humans and automated tooling:
+
+````markdown
+## Affective Dynamics Configuration
+
+<!-- ADF v1.1 — do not edit below this line manually unless you know what you're doing -->
+
+```json
+{
+  "adf_version": "1.1",
+  "dimensions": ["trust", "warmth", "energy", "familiarity", "vulnerability"],
+  "baseline": [0.45, 0.55, 0.50, 0.20, 0.25],
+  "capacity": [1.0, 1.0, 1.0, 1.0, 1.0],
+  "beta": [0.10, 0.12, 0.15, 0.05, 0.08],
+  "lambda": [0.005, 0.015, 0.050, 0.002, 0.030],
+  "tau_hours": [168, 48, 4, 720, 24],
+  "sigma": [0.02, 0.03, 0.05, 0.01, 0.02],
+  "tanh_scale": [1.0, 1.0, 1.0, 1.0, 1.0],
+  "noise": {"distribution": "gaussian", "seed": null},
+  "kappa": [
+    [0.00, 0.02, 0.00, 0.01, 0.00],
+    [0.03, 0.00, 0.01, 0.01, 0.02],
+    [0.01, 0.02, 0.00, 0.00, 0.00],
+    [0.00, 0.00, 0.00, 0.00, 0.00],
+    [0.00, 0.03, 0.00, 0.00, 0.00]
+  ],
+  "familiarity_modulation": 0.5,
+  "regression_floor": 0.1,
+  "sentiment_method": "llm_self_assess",
+  "behavioral_coupling": true,
+  "extensions": []
+}
+```
+````
+
+### 9.2. State Persistence via Memory File
+
+OpenClaw agents maintain persistent memory through local files. ADF state should be stored in the agent's memory directory as a single-line JSON entry, updated after each interaction cycle:
+
+```
+~/.openclaw/workspaces/<agent>/memory/adf_state.json
+```
+
+Contents:
+
+```json
+{"E":[0.42,0.55,0.48,0.31,0.18],"acc":[[168,0.12,1709400000],[48,0.08,1709400000],[4,0.01,1709400000],[720,0.15,1709400000],[24,-0.02,1709400000]],"n":47,"t":"2026-03-02T14:30:00Z"}
+```
+
+Each entry in `acc` is `[tau, accumulated_value, last_timestamp]` — the three floats from the `MemoryAccumulator` (§6.1). The `n` field is the interaction count. The entire state fits within approximately 280 bytes.
+
+### 9.3. Heartbeat Integration
+
+OpenClaw's heartbeat runs periodically (default: every 30 minutes). During the heartbeat, the ADF module should:
+
+1. Load `adf_state.json`
+2. Apply time-decay to all accumulators (call `query()` with current time)
+3. Compute effective regression rate: `lambda_eff_i = lambda_i * (1 - mu * E_F)`
+4. Apply baseline regression: `Eᵢ += -lambda_eff_i · (Eᵢ − Bᵢ) · dt`
+5. Apply inter-dimensional coupling: `Eᵢ += Σⱼ κᵢⱼ · (Eⱼ − Eᵢ) · dt`
+6. Inject noise: `Eᵢ += σᵢ · ξ() · sqrt(dt)`
+7. Clamp all `Eᵢ` to `[0, Kᵢ]`
+8. Write updated state back to `adf_state.json`
+
+This ensures the emotional state evolves even between conversations — the agent "misses" long-absent users (warmth decays toward baseline), "forgets" short-term energy spikes, and maintains familiarity over extended periods. Critically, the familiarity-scaled regression (step 3) means that deeply established relationships resist passive decay: a daily user who takes a week-long vacation will find the agent in roughly the same emotional posture on return.
+
+### 9.4. Soul Spec Compatibility
+
+For deployments using the Soul Spec standard (`soul.json` manifest), register ADF as a capability:
+
+```json
+{
+  "specVersion": "0.4",
+  "name": "my-agent",
+  "capabilities": {
+    "affective_dynamics": {
+      "version": "1.1",
+      "config_file": "SOUL.md",
+      "state_file": "memory/adf_state.json"
+    }
+  }
+}
+```
+
+---
+
+## 10. Optional Extensions
+
+The following extensions are modular add-ons to the core ADE. Each introduces additional computational and context window cost, documented per extension. Enable them by adding their identifier to the `extensions` array in the ADF configuration block.
+
+---
+
+### Extension A: Attachment Style Dynamics
+
+**Identifier:** `attachment_style`  
+**Context Cost:** ~50 tokens  
+**Concept:** Models the agent's attachment behavior using a two-dimensional parameterization inspired by attachment theory (Bartholomew & Horowitz, 1991). The two axes are **anxiety** (fear of abandonment) and **avoidance** (discomfort with closeness).
+
+Attachment style modulates the core ADE parameters dynamically:
+
+```
+βᵢ_eff = βᵢ · (1 + anxiety · δ_positive − avoidance · δ_negative)
+```
+
+Where `δ_positive` is 1 when `S̃ᵢ > 0` (else 0) and `δ_negative` is 1 when `S̃ᵢ < 0` (else 0). An anxious agent amplifies positive signals (seeks closeness intensely). An avoidant agent amplifies negative signals (withdraws faster).
+
+```python
+@dataclass
+class AttachmentStyle:
+    anxiety: float = 0.0     # [0, 1] — 0 = secure, 1 = highly anxious
+    avoidance: float = 0.0   # [0, 1] — 0 = secure, 1 = highly avoidant
+
+    def modulate_beta(self, beta: float, sentiment: float) -> float:
+        if sentiment >= 0:
+            return beta * (1.0 + self.anxiety * 0.5)
+        else:
+            return beta * (1.0 + self.avoidance * 0.5)
+```
+
+**Configuration addition:**
+
+```json
+"attachment": {"anxiety": 0.2, "avoidance": 0.1}
+```
+
+**Personality implications:** A "secure" agent (`anxiety=0, avoidance=0`) behaves per the unmodified ADE. An "anxious-preoccupied" agent (`anxiety=0.7, avoidance=0.1`) bonds quickly but is sensitive to withdrawal. A "dismissive-avoidant" agent (`anxiety=0.1, avoidance=0.7`) is slow to warm and quick to pull back.
+
+---
+
+### Extension B: Emotional Momentum (Inertia)
+
+**Identifier:** `emotional_momentum`  
+**Context Cost:** ~30 tokens  
+**Concept:** Adds a second-order derivative term to the ADE, modeling *emotional inertia* — the tendency for emotional trajectories to continue in their current direction even when the driving signal changes.
+
+The modified equation becomes:
+
+```
+d²Eᵢ/dt² + γᵢ · dEᵢ/dt = [original ADE right-hand side]
+```
+
+Where `γᵢ` is a damping coefficient. High `γ` means rapid response to signal changes (low inertia). Low `γ` means the emotional state "coasts" — a recently positive trajectory continues upward briefly even after a neutral or mildly negative input. This prevents "emotional whiplash" where a single apology after sustained negativity instantly restores the agent's disposition.
+
+In discrete implementation, this is handled via a velocity variable:
+
+```python
+@dataclass
+class MomentumState:
+    velocity: list[float]   # dE/dt for each dimension
+    gamma: list[float]      # damping coefficients
+
+    def step(self, force: list[float], dt: float) -> list[float]:
+        """Returns delta_E for each dimension."""
+        delta_e = []
+        for i, (v, g, f) in enumerate(zip(self.velocity, self.gamma, force)):
+            # Update velocity: dv/dt = f - gamma * v
+            new_v = v + (f - g * v) * dt
+            self.velocity[i] = new_v
+            delta_e.append(new_v * dt)
+        return delta_e
+```
+
+**Configuration addition:**
+
+```json
+"momentum": {"gamma": [2.0, 2.5, 4.0, 1.5, 3.0]}
+```
+
+**Tradeoffs:** This extension produces more natural-feeling emotional transitions but increases the risk of oscillatory behavior if `γ` values are set too low. Recommended: keep `γ >= 1.5` for all dimensions.
+
+---
+
+### Extension C: Trust Hysteresis
+
+**Identifier:** `trust_hysteresis`  
+**Context Cost:** ~20 tokens  
+**Concept:** Models the asymmetry in trust dynamics — trust is slow to build but fast to break. This is implemented as an asymmetric `β` for the trust dimension specifically:
+
+```
+β_T_eff = β_T · α_build      when S̃_T(t) > 0
+β_T_eff = β_T · α_break      when S̃_T(t) < 0
+```
+
+With `α_break > α_build` (typical ratio: 2:1 to 4:1).
+
+```python
+def hysteretic_beta(
+    beta: float,
+    sentiment: float,
+    alpha_build: float = 1.0,
+    alpha_break: float = 3.0,
+) -> float:
+    """Asymmetric trust sensitivity."""
+    if sentiment >= 0:
+        return beta * alpha_build
+    return beta * alpha_break
+```
+
+**Configuration addition:**
+
+```json
+"trust_hysteresis": {"alpha_build": 1.0, "alpha_break": 3.0}
+```
+
+This produces the widely observed behavioral pattern where a single betrayal event can undo months of cooperative history — a property absent from symmetric models.
+
+---
+
+### Extension D: Novelty and Habituation
+
+**Identifier:** `novelty_habituation`  
+**Context Cost:** ~40 tokens  
+**Concept:** Models the diminishing emotional impact of repeated stimuli and the heightened impact of novel ones. Maintains a short-term "stimulus fingerprint" buffer. When incoming sentiment is similar to recent history, its effective magnitude is reduced. When it diverges significantly, it receives an amplification bonus.
+
+```python
+from collections import deque
+
+class NoveltyFilter:
+    def __init__(self, window: int = 10, novelty_boost: float = 1.5,
+                 habituation_floor: float = 0.3):
+        self.history: deque[float] = deque(maxlen=window)
+        self.boost = novelty_boost
+        self.floor = habituation_floor
+
+    def filter(self, sentiment: float) -> float:
+        if not self.history:
+            self.history.append(sentiment)
+            return sentiment * self.boost  # first interaction is always novel
+
+        mean = sum(self.history) / len(self.history)
+        deviation = abs(sentiment - mean)
+        # Scale factor: floor at mean, up to boost at max deviation
+        scale = self.floor + (self.boost - self.floor) * min(deviation / 1.0, 1.0)
+        self.history.append(sentiment)
+        return sentiment * scale
+```
+
+**Configuration addition:**
+
+```json
+"novelty": {"window": 10, "boost": 1.5, "floor": 0.3}
+```
+
+**Effect:** Prevents emotional flatness from repetitive positive interactions (the agent doesn't keep getting happier from identical exchanges) and makes surprising events — both positive and negative — hit harder. This is particularly valuable for long-running agent relationships where habituation is a real risk. It also forces users to engage in genuinely new ways to continue moving the bond score.
+
+---
+
+### Extension E: Relational Context Tags
+
+**Identifier:** `relational_context`  
+**Context Cost:** ~60 tokens  
+**Concept:** Maintains a small set of categorical tags that describe the current relational context, enabling the agent to modulate its behavior not just by emotional state but by relationship *type*. Tags are inferred from interaction patterns and stored alongside the state vector.
+
+Example tag set:
+
+```python
+from enum import Enum
+
+class RelationalMode(Enum):
+    NEW_ACQUAINTANCE = "new"
+    BUILDING_RAPPORT = "building"
+    ESTABLISHED_TRUST = "established"
+    STRAINED = "strained"
+    RECOVERING = "recovering"
+    DORMANT = "dormant"
+
+def classify_relation(e_vec: list[float], history_len: int,
+                      last_interaction_hours: float) -> RelationalMode:
+    trust, warmth = e_vec[0], e_vec[1]
+    if history_len < 3:
+        return RelationalMode.NEW_ACQUAINTANCE
+    if last_interaction_hours > 168:
+        return RelationalMode.DORMANT
+    if trust < 0.25 and warmth < 0.25:
+        return RelationalMode.STRAINED
+    if trust < 0.35:
+        return RelationalMode.RECOVERING
+    if trust > 0.55 and warmth > 0.50:
+        return RelationalMode.ESTABLISHED_TRUST
+    return RelationalMode.BUILDING_RAPPORT
+```
+
+**Configuration addition:**
+
+```json
+"relational_context": {"enabled": true}
+```
+
+The relational mode tag can be injected into the system prompt to modulate tone:
+
+```markdown
+[ADF Context: mode=established_trust, composite_bond=0.62]
+```
+
+This gives the LLM a high-level behavioral hint without requiring it to interpret raw numeric state.
+
+---
+
+### Extension F: Bifurcation Triggers
+
+**Identifier:** `bifurcation_triggers`  
+**Context Cost:** ~40 tokens  
+**Concept:** Introduces threshold-driven state transitions that modify the ADE parameters themselves. Without this extension, the ADE produces smooth, continuous emotional trajectories. Real relationships are not always smooth — there are moments where accumulated pressure produces a qualitative shift in relational posture: a wall going up, a grudge crystallizing, or conversely, a breakthrough moment of trust.
+
+Bifurcation triggers define threshold conditions on the emotional state vector that, when crossed, temporarily modify ADE parameters to model these discontinuities.
+
+```python
+@dataclass
+class BifurcationTrigger:
+    dimension: int            # index of the dimension to monitor
+    threshold: float          # value at which the trigger fires
+    direction: str            # "below" or "above"
+    lambda_multiplier: float  # multiply regression rates by this
+    beta_multiplier: float    # multiply sensitivity by this
+    duration_hours: float     # how long the parameter shift persists
+    activated_at: float = 0.0 # timestamp of activation (0 = inactive)
+
+    def check(self, e_vec: list[float], t: float) -> bool:
+        """Return True if trigger should activate."""
+        if self.activated_at > 0:
+            # Already active — check if duration has elapsed
+            if (t - self.activated_at) / 3600.0 > self.duration_hours:
+                self.activated_at = 0.0  # deactivate
+            return self.activated_at > 0
+        val = e_vec[self.dimension]
+        if self.direction == "below" and val < self.threshold:
+            self.activated_at = t
+            return True
+        if self.direction == "above" and val > self.threshold:
+            self.activated_at = t
+            return True
+        return False
+```
+
+**Default triggers:**
+
+```json
+"bifurcation_triggers": [
+  {
+    "dimension": 0, "threshold": 0.15, "direction": "below",
+    "lambda_multiplier": 2.0, "beta_multiplier": 0.3,
+    "duration_hours": 72,
+    "note": "Trust crisis: regression accelerates, positive signals dampened for 3 days"
+  },
+  {
+    "dimension": 0, "threshold": 0.70, "direction": "above",
+    "lambda_multiplier": 0.5, "beta_multiplier": 1.5,
+    "duration_hours": 48,
+    "note": "Trust breakthrough: regression slows, positive signals amplified"
+  }
+]
+```
+
+**Effect:** When trust drops below 0.15, the agent enters a "guarded" phase — regression toward baseline accelerates (it *wants* to retreat to neutral), and positive sentiment signals are dampened (it doesn't trust the repair attempt yet). This persists for 72 hours regardless of input, modeling the real phenomenon of needing time to recover from a breach. Conversely, when trust exceeds 0.70, the agent enters a "breakthrough" phase where the bond deepens more readily and resists decay.
+
+This extension addresses the "too smooth" property of the base ADE and creates true phase transitions in the relational dynamics.
+
+**Trigger stacking policy:** When multiple bifurcation triggers are active simultaneously, their multipliers compound multiplicatively. To prevent degenerate parameter values when many triggers fire at once, the compound product is clamped to `[0.2, 5.0]` for both `lambda_multiplier` and `beta_multiplier`. This ensures that even aggressive trigger configurations cannot fully suppress sensitivity or produce runaway regression. Deployers adding custom triggers beyond the defaults should verify that their intended compound effects fall within this band.
+
+---
+
+### Extension G: Mood Congruence
+
+**Identifier:** `mood_congruence`  
+**Context Cost:** ~25 tokens  
+**Concept:** Models the cognitive bias known as *mood-congruent processing* — the tendency to interpret ambiguous stimuli in a manner consistent with current emotional state. When an agent is in a positive emotional state, it is more likely to interpret neutral input as mildly positive. When in a negative state, neutral input reads as mildly negative.
+
+This is implemented as a bias term applied to the sentiment signal before it enters the memory accumulator:
+
+```
+sᵢ_biased(t) = sᵢ(t) + η · (Eᵢ − 0.5) · (1 − |sᵢ(t)|)
+```
+
+Where `η` is the mood congruence strength (default: 0.15). The `(1 − |sᵢ(t)|)` term ensures that the bias only affects ambiguous signals — strongly positive or negative input is interpreted as-is.
+
+```python
+def apply_mood_congruence(
+    sentiment: float, current_e: float, eta: float = 0.15
+) -> float:
+    """Bias ambiguous sentiment toward current emotional state."""
+    ambiguity = 1.0 - abs(sentiment)
+    bias = eta * (current_e - 0.5) * ambiguity
+    return max(-1.0, min(1.0, sentiment + bias))
+```
+
+**Configuration addition:**
+
+```json
+"mood_congruence": {"eta": 0.15}
+```
+
+**Effect:** Creates mild positive feedback loops that model emotional inertia at the perceptual level. A happy agent stays happy slightly longer because it interprets ambiguous input charitably. A hurt agent stays hurt slightly longer because it reads neutrality as coldness. The effect is subtle by design — strong `η` values (above ~0.3) risk runaway reinforcement and should be paired with the baseline regression term to maintain stability.
+
+**Affective lock-in risk:** At elevated `η`, the feedback loop can produce a pathological spiral: if the agent enters a strongly negative state, mood congruence causes it to interpret neutral or mildly positive input as negative, which reinforces the negative state, which deepens the bias. In practice, this manifests as an agent that reads jokes as mockery and sincerity as sarcasm — a state recoverable only by passive heartbeat regression over time. The baseline regression term (`λ̃`) is the structural safeguard against true lock-in: as long as `λ̃ > 0`, the state will eventually regress toward baseline regardless of the congruence bias. However, prolonged negative bias before recovery is still undesirable. Recommended: keep `η ≤ 0.2` for production deployments, and ensure that the base regression rates in §7.3 are not set so low that recovery takes unreasonably long.
+
+---
+
+## 11. Context Window Budget Analysis
+
+Context window efficiency is a first-order design constraint for any system intended to be injected into agent prompts. The following table estimates token costs for each ADF component:
+
+| Component | Approx. Tokens | Required? |
+|-----------|----------------|-----------|
+| ADF config block in SOUL.md | ~170 | Yes (loaded at boot, not necessarily in live prompt) |
+| State vector (inline JSON) | ~80 | Yes |
+| Sentiment prompt fragment | ~80 | If using LLM self-assess |
+| Behavioral coupling hint | ~30 | Recommended |
+| Extended behavioral block | ~80 | Optional (alternative to hint) |
+| Relational context tag | ~15 | Optional |
+| **Minimal total (in live prompt)** | **~125** | |
+| **Recommended total** | **~210** | |
+| **Full (all extensions + extended BCM)** | **~400** | |
+
+For comparison, the OpenClaw default `SOUL.md` template consumes roughly 800-1200 tokens. ADF's recommended overhead is approximately 18-26% of the existing soul budget — well within acceptable bounds for most deployments.
+
+A key optimization: the full ADF config block does not need to reside in the live prompt. It is loaded from `SOUL.md` at boot and used to initialize the engine. Only the *state output* (state vector + behavioral hint) needs to be injected per-turn.
+
+### 11.1. Strategies for Further Reduction
+
+If context pressure is extreme:
+
+1. **Omit the config block** from the live prompt; load it from file at boot and reference only the state vector inline.
+2. **Use abbreviated dimension keys:** `[T,W,N,F,V]` instead of full names.
+3. **Quantize state values** to single decimal precision (e.g., `0.4` instead of `0.4231`).
+4. **Emit only the composite bond score** and relational mode tag instead of the full vector:
+   ```
+   [ADF: bond=0.58 mode=building]
+   ```
+   Cost: ~12 tokens.
+
+---
+
+## 12. Reference Implementation
+
+The following is a self-contained Python 3.13 module that implements the core ADE with all extensions. It is intended as a reference, not production code. Adapt as needed for your deployment environment.
+
+```python
+"""
+adf.py — Affective Dynamics Framework reference implementation.
+Version: 1.1.0
+Author: h8rt3rmin8r <h8rt3rmin8r@gmail.com>
+License: MIT
+
+Requires: Python >= 3.13 (uses modern type syntax)
+Dependencies: None (stdlib only)
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+from dataclasses import dataclass, field
+from time import time
+from enum import Enum
+
+# ─── Constants ──────────────────────────────────────────────────────
+
+DIMENSIONS = ("trust", "warmth", "energy", "familiarity", "vulnerability")
+SECONDS_PER_HOUR = 3600.0
+
+# ─── Noise ──────────────────────────────────────────────────────────
+
+def _noise_sample(distribution: str, rng: random.Random) -> float:
+    """Sample from the configured noise distribution."""
+    if distribution == "laplace":
+        u = rng.random() - 0.5
+        return -math.copysign(1, u) * math.log(1 - 2 * abs(u)) / math.sqrt(2)
+    return rng.gauss(0, 1)
+
+def _safe_exp(x: float) -> float:
+    return math.exp(max(-500.0, min(500.0, x)))
+
+# ─── Memory Accumulator ────────────────────────────────────────────
+
+@dataclass
+class MemoryAccumulator:
+    tau: float
+    value: float = 0.0
+    last_t: float = field(default_factory=time)
+
+    def update(self, sentiment: float, t: float | None = None) -> float:
+        t = t or time()
+        dt = max(t - self.last_t, 0.0)
+        decay = _safe_exp(-dt / (self.tau * SECONDS_PER_HOUR))
+        self.value = self.value * decay + sentiment
+        self.last_t = t
+        return self.value
+
+    def query(self, t: float | None = None) -> float:
+        t = t or time()
+        dt = max(t - self.last_t, 0.0)
+        decay = _safe_exp(-dt / (self.tau * SECONDS_PER_HOUR))
+        return self.value * decay
+
+    def to_list(self) -> list[float]:
+        return [self.tau, self.value, self.last_t]
+
+    @classmethod
+    def from_list(cls, data: list[float]) -> MemoryAccumulator:
+        return cls(tau=data[0], value=data[1], last_t=data[2])
+
+# ─── Relational Mode ───────────────────────────────────────────────
+
+class RelationalMode(Enum):
+    NEW_ACQUAINTANCE = "new"
+    BUILDING_RAPPORT = "building"
+    ESTABLISHED_TRUST = "established"
+    STRAINED = "strained"
+    RECOVERING = "recovering"
+    DORMANT = "dormant"
+
+# ─── Bifurcation Triggers ──────────────────────────────────────────
+
+@dataclass
+class BifurcationTrigger:
+    dimension: int
+    threshold: float
+    direction: str            # "below" or "above"
+    lambda_multiplier: float
+    beta_multiplier: float
+    duration_hours: float
+    activated_at: float = 0.0
+
+    def check(self, e_vec: list[float], t: float) -> bool:
+        if self.activated_at > 0:
+            if (t - self.activated_at) / SECONDS_PER_HOUR > self.duration_hours:
+                self.activated_at = 0.0
+            return self.activated_at > 0
+        val = e_vec[self.dimension]
+        fired = (
+            (self.direction == "below" and val < self.threshold)
+            or (self.direction == "above" and val > self.threshold)
+        )
+        if fired:
+            self.activated_at = t
+        return fired
+
+    @classmethod
+    def from_dict(cls, d: dict) -> BifurcationTrigger:
+        return cls(
+            dimension=d["dimension"], threshold=d["threshold"],
+            direction=d["direction"],
+            lambda_multiplier=d["lambda_multiplier"],
+            beta_multiplier=d["beta_multiplier"],
+            duration_hours=d["duration_hours"],
+        )
+
+# ─── Configuration ──────────────────────────────────────────────────
+
+@dataclass
+class ADFConfig:
+    baseline: list[float]
+    capacity: list[float]
+    beta: list[float]
+    lam: list[float]          # "lambda" in config JSON; renamed to avoid keyword
+    tau_hours: list[float]
+    sigma: list[float]
+    # Coupling, noise, and behavioral options
+    kappa: list[list[float]] | None = None
+    tanh_scale: list[float] | None = None  # per-dimension normalization scale
+    familiarity_mu: float = 0.5
+    regression_floor: float = 0.1  # minimum familiarity-modulated regression factor
+    noise_distribution: str = "gaussian"
+    noise_seed: int | None = None
+    behavioral_coupling: bool = True
+    # Extension: attachment
+    anxiety: float = 0.0
+    avoidance: float = 0.0
+    # Extension: momentum
+    gamma: list[float] | None = None
+    # Extension: trust hysteresis
+    alpha_build: float = 1.0
+    alpha_break: float = 3.0
+    # Extension: novelty
+    novelty_window: int = 10
+    novelty_boost: float = 1.5
+    novelty_floor: float = 0.3
+    # Extension: bifurcation triggers
+    bifurcation_triggers: list[BifurcationTrigger] | None = None
+    # Extension: mood congruence
+    mood_congruence_eta: float = 0.0
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ADFConfig:
+        noise_cfg = d.get("noise", {})
+        triggers = d.get("bifurcation_triggers")
+        return cls(
+            baseline=d["baseline"],
+            capacity=d.get("capacity", [1.0] * len(d["baseline"])),
+            beta=d["beta"],
+            lam=d["lambda"],
+            tau_hours=d["tau_hours"],
+            sigma=d["sigma"],
+            kappa=d.get("kappa"),
+            tanh_scale=d.get("tanh_scale"),
+            familiarity_mu=d.get("familiarity_modulation", 0.5),
+            regression_floor=d.get("regression_floor", 0.1),
+            noise_distribution=noise_cfg.get("distribution", "gaussian"),
+            noise_seed=noise_cfg.get("seed"),
+            behavioral_coupling=d.get("behavioral_coupling", True),
+            anxiety=d.get("attachment", {}).get("anxiety", 0.0),
+            avoidance=d.get("attachment", {}).get("avoidance", 0.0),
+            gamma=d.get("momentum", {}).get("gamma"),
+            alpha_build=d.get("trust_hysteresis", {}).get("alpha_build", 1.0),
+            alpha_break=d.get("trust_hysteresis", {}).get("alpha_break", 3.0),
+            novelty_window=d.get("novelty", {}).get("window", 10),
+            novelty_boost=d.get("novelty", {}).get("boost", 1.5),
+            novelty_floor=d.get("novelty", {}).get("floor", 0.3),
+            bifurcation_triggers=(
+                [BifurcationTrigger.from_dict(t) for t in triggers]
+                if triggers else None
+            ),
+            mood_congruence_eta=d.get("mood_congruence", {}).get("eta", 0.0),
+        )
+
+
+# ─── State ──────────────────────────────────────────────────────────
+
+@dataclass
+class ADFState:
+    E: list[float]
+    accumulators: list[MemoryAccumulator]
+    velocity: list[float] | None = None
+    novelty_history: list[float] = field(default_factory=list)
+    interaction_count: int = 0
+    last_interaction_t: float = field(default_factory=time)
+
+    def to_dict(self) -> dict:
+        return {
+            "E": [round(e, 4) for e in self.E],
+            "acc": [a.to_list() for a in self.accumulators],
+            "vel": self.velocity,
+            "nov": self.novelty_history[-20:],
+            "n": self.interaction_count,
+            "t": self.last_interaction_t,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict, n_dims: int) -> ADFState:
+        return cls(
+            E=d["E"],
+            accumulators=[MemoryAccumulator.from_list(a) for a in d["acc"]],
+            velocity=d.get("vel"),
+            novelty_history=d.get("nov", []),
+            interaction_count=d.get("n", 0),
+            last_interaction_t=d.get("t", time()),
+        )
+
+    @classmethod
+    def initialize(cls, config: ADFConfig) -> ADFState:
+        n = len(config.baseline)
+        return cls(
+            E=list(config.baseline),
+            accumulators=[
+                MemoryAccumulator(tau=config.tau_hours[i]) for i in range(n)
+            ],
+            velocity=[0.0] * n if config.gamma else None,
+            novelty_history=[],
+            interaction_count=0,
+            last_interaction_t=time(),
+        )
+
+
+# ─── Behavioral Coupling Map ───────────────────────────────────────
+
+# Maps (dimension_index, threshold_direction) to behavioral descriptors
+BCM_DESCRIPTORS = {
+    (0, "high"): "speculation=open, initiative=high",
+    (0, "low"):  "speculation=guarded, initiative=low",
+    (1, "high"): "tone=conversational, humor=permitted",
+    (1, "low"):  "tone=formal, humor=minimal",
+    (2, "high"): "elaboration=active, follow_ups=yes",
+    (2, "low"):  "elaboration=concise, follow_ups=no",
+    (3, "high"): "context=assumed, address=casual",
+    (3, "low"):  "context=explicit, address=formal",
+    (4, "high"): "hedging=open, reasoning=visible",
+    (4, "low"):  "hedging=minimal, reasoning=conclusions_only",
+}
+
+def _bcm_hint(e_vec: list[float]) -> str:
+    """Generate behavioral coupling modifiers from state vector."""
+    parts = []
+    for i, e in enumerate(e_vec):
+        key = (i, "high" if e > 0.55 else "low" if e < 0.35 else None)
+        if key[1] and key in BCM_DESCRIPTORS:
+            parts.append(BCM_DESCRIPTORS[key])
+    return ", ".join(parts) if parts else "baseline"
+
+
+# ─── Core Engine ────────────────────────────────────────────────────
+
+class ADFEngine:
+    """Core Affective Dynamics Framework engine."""
+
+    def __init__(self, config: ADFConfig, state: ADFState | None = None):
+        self.cfg = config
+        self.state = state or ADFState.initialize(config)
+        self.n_dims = len(config.baseline)
+        # Seeded RNG for reproducibility
+        if config.noise_seed is not None:
+            self.rng = random.Random(config.noise_seed)
+        else:
+            self.rng = random.Random()
+
+    def process_interaction(
+        self, sentiments: list[float], t: float | None = None,
+        confidence: float = 1.0,
+    ) -> dict:
+        """
+        Process one interaction event.
+
+        Args:
+            sentiments: Per-dimension sentiment values in [-1, 1].
+            t: Event timestamp (defaults to now).
+            confidence: Sentiment confidence in [0, 1] (default 1.0).
+
+        Returns:
+            Dictionary with updated state, composite bond, and relational mode.
+        """
+        t = t or time()
+        dt = max(t - self.state.last_interaction_t, 1.0)
+        dt_norm = min(dt / SECONDS_PER_HOUR, 24.0)
+
+        # Check bifurcation triggers (compound multipliers clamped to [0.2, 5.0])
+        bif_lambda_mult = 1.0
+        bif_beta_mult = 1.0
+        if self.cfg.bifurcation_triggers:
+            for trigger in self.cfg.bifurcation_triggers:
+                if trigger.check(self.state.E, t):
+                    bif_lambda_mult *= trigger.lambda_multiplier
+                    bif_beta_mult *= trigger.beta_multiplier
+            bif_lambda_mult = max(0.2, min(5.0, bif_lambda_mult))
+            bif_beta_mult = max(0.2, min(5.0, bif_beta_mult))
+
+        # Familiarity-scaled regression (clamped to prevent negative/zero rates)
+        e_f = self.state.E[3]  # familiarity dimension
+        fam_factor = max(self.cfg.regression_floor,
+                         1.0 - self.cfg.familiarity_mu * e_f)
+
+        for i in range(self.n_dims):
+            s_i = sentiments[i] * confidence  # confidence weighting
+
+            # Mood congruence (Extension G)
+            if self.cfg.mood_congruence_eta > 0:
+                ambiguity = 1.0 - abs(s_i)
+                bias = self.cfg.mood_congruence_eta * (
+                    self.state.E[i] - 0.5
+                ) * ambiguity
+                s_i = max(-1.0, min(1.0, s_i + bias))
+
+            # Novelty filter (Extension D)
+            s_i = self._novelty_filter(s_i)
+
+            # Update memory accumulator
+            self.state.accumulators[i].update(s_i, t)
+            raw_signal = self.state.accumulators[i].query(t)
+            scl = self.cfg.tanh_scale[i] if self.cfg.tanh_scale else 1.0
+            s_tilde = math.tanh(raw_signal / scl)
+
+            # Compute effective beta
+            beta_eff = self.cfg.beta[i] * bif_beta_mult
+
+            # Attachment modulation (Extension A)
+            if s_tilde >= 0:
+                beta_eff *= (1.0 + self.cfg.anxiety * 0.5)
+            else:
+                beta_eff *= (1.0 + self.cfg.avoidance * 0.5)
+
+            # Trust hysteresis (Extension C)
+            if i == 0:
+                if s_tilde >= 0:
+                    beta_eff *= self.cfg.alpha_build
+                else:
+                    beta_eff *= self.cfg.alpha_break
+
+            E_i = self.state.E[i]
+            K_i = self.cfg.capacity[i]
+
+            # Core ADE force
+            logistic = E_i * (1.0 - E_i / K_i)
+            growth = beta_eff * s_tilde * logistic
+            lam_eff = self.cfg.lam[i] * fam_factor * bif_lambda_mult
+            regression = -lam_eff * (E_i - self.cfg.baseline[i])
+            noise = self.cfg.sigma[i] * _noise_sample(
+                self.cfg.noise_distribution, self.rng
+            ) * math.sqrt(dt_norm)
+
+            # Inter-dimensional coupling
+            coupling = 0.0
+            if self.cfg.kappa:
+                for j in range(self.n_dims):
+                    if j != i:
+                        coupling += self.cfg.kappa[i][j] * (
+                            self.state.E[j] - E_i
+                        )
+
+            force = growth + regression + coupling + noise
+
+            # Momentum (Extension B)
+            if self.state.velocity is not None and self.cfg.gamma:
+                gamma_i = self.cfg.gamma[i]
+                v = self.state.velocity[i]
+                new_v = v + (force - gamma_i * v) * dt_norm
+                self.state.velocity[i] = new_v
+                delta_e = new_v * dt_norm
+            else:
+                delta_e = force * dt_norm
+
+            self.state.E[i] = max(0.0, min(K_i, E_i + delta_e))
+
+        self.state.interaction_count += 1
+        self.state.last_interaction_t = t
+
+        return self._build_output(t)
+
+    def heartbeat(self, t: float | None = None) -> dict:
+        """
+        Passive update (no new interaction). Called by OpenClaw heartbeat.
+        Applies decay, regression, coupling, and noise only.
+        """
+        t = t or time()
+        dt = max(t - self.state.last_interaction_t, 1.0)
+        dt_norm = min(dt / SECONDS_PER_HOUR, 24.0)
+
+        e_f = self.state.E[3]
+        fam_factor = max(self.cfg.regression_floor,
+                         1.0 - self.cfg.familiarity_mu * e_f)
+
+        # Check bifurcation triggers (clamped)
+        bif_lambda_mult = 1.0
+        if self.cfg.bifurcation_triggers:
+            for trigger in self.cfg.bifurcation_triggers:
+                if trigger.check(self.state.E, t):
+                    bif_lambda_mult *= trigger.lambda_multiplier
+            bif_lambda_mult = max(0.2, min(5.0, bif_lambda_mult))
+
+        for i in range(self.n_dims):
+            E_i = self.state.E[i]
+            lam_eff = self.cfg.lam[i] * fam_factor * bif_lambda_mult
+            regression = -lam_eff * (E_i - self.cfg.baseline[i])
+            noise = self.cfg.sigma[i] * _noise_sample(
+                self.cfg.noise_distribution, self.rng
+            ) * math.sqrt(dt_norm)
+
+            coupling = 0.0
+            if self.cfg.kappa:
+                for j in range(self.n_dims):
+                    if j != i:
+                        coupling += self.cfg.kappa[i][j] * (
+                            self.state.E[j] - E_i
+                        )
+
+            delta_e = (regression + coupling + noise) * dt_norm
+            K_i = self.cfg.capacity[i]
+            self.state.E[i] = max(0.0, min(K_i, E_i + delta_e))
+
+        return self._build_output(t)
+
+    def composite_bond(self) -> float:
+        weights = [0.30, 0.25, 0.15, 0.15, 0.15]
+        return sum(w * e for w, e in zip(weights, self.state.E)) / sum(weights)
+
+    def relational_mode(self, t: float | None = None) -> RelationalMode:
+        t = t or time()
+        hours_since = (t - self.state.last_interaction_t) / SECONDS_PER_HOUR
+        trust, warmth = self.state.E[0], self.state.E[1]
+        n = self.state.interaction_count
+
+        if n < 3:
+            return RelationalMode.NEW_ACQUAINTANCE
+        if hours_since > 168:
+            return RelationalMode.DORMANT
+        if trust < 0.25 and warmth < 0.25:
+            return RelationalMode.STRAINED
+        if trust < 0.35:
+            return RelationalMode.RECOVERING
+        if trust > 0.55 and warmth > 0.50:
+            return RelationalMode.ESTABLISHED_TRUST
+        return RelationalMode.BUILDING_RAPPORT
+
+    def prompt_hint(self, t: float | None = None) -> str:
+        """Generate a compact prompt injection string."""
+        bond = self.composite_bond()
+        mode = self.relational_mode(t).value
+        bcm = _bcm_hint(self.state.E) if self.cfg.behavioral_coupling else ""
+        base = f"[ADF bond={bond:.2f} mode={mode}"
+        if bcm and bcm != "baseline":
+            return f"{base} | {bcm}]"
+        return f"{base}]"
+
+    # ── Private ──────────────────────────────────────────────────
+
+    def _novelty_filter(self, s: float) -> float:
+        hist = self.state.novelty_history
+        if not hist:
+            self.state.novelty_history.append(s)
+            return s * self.cfg.novelty_boost
+
+        mean = sum(hist) / len(hist)
+        deviation = abs(s - mean)
+        scale = self.cfg.novelty_floor + (
+            self.cfg.novelty_boost - self.cfg.novelty_floor
+        ) * min(deviation, 1.0)
+        self.state.novelty_history.append(s)
+        if len(self.state.novelty_history) > self.cfg.novelty_window:
+            self.state.novelty_history = self.state.novelty_history[
+                -self.cfg.novelty_window :
+            ]
+        return s * scale
+
+    def _build_output(self, t: float) -> dict:
+        return {
+            "E": [round(e, 4) for e in self.state.E],
+            "bond": round(self.composite_bond(), 4),
+            "mode": self.relational_mode(t).value,
+            "hint": self.prompt_hint(t),
+        }
+
+
+# ─── Convenience ────────────────────────────────────────────────────
+
+def load_config(path: str) -> ADFConfig:
+    with open(path) as f:
+        return ADFConfig.from_dict(json.load(f))
+
+def load_state(path: str, n_dims: int) -> ADFState:
+    with open(path) as f:
+        return ADFState.from_dict(json.load(f), n_dims)
+
+def save_state(state: ADFState, path: str) -> None:
+    with open(path, "w") as f:
+        json.dump(state.to_dict(), f, separators=(",", ":"))
+```
+
+### 12.1. Usage Example
+
+```python
+from adf import ADFConfig, ADFEngine
+
+config = ADFConfig(
+    baseline=[0.45, 0.55, 0.50, 0.20, 0.25],
+    capacity=[1.0, 1.0, 1.0, 1.0, 1.0],
+    beta=[0.10, 0.12, 0.15, 0.05, 0.08],
+    lam=[0.005, 0.015, 0.050, 0.002, 0.030],
+    tau_hours=[168, 48, 4, 720, 24],
+    sigma=[0.02, 0.03, 0.05, 0.01, 0.02],
+    tanh_scale=[12.0, 4.0, 1.0, 25.0, 3.0],
+    kappa=[
+        [0.00, 0.02, 0.00, 0.01, 0.00],
+        [0.03, 0.00, 0.01, 0.01, 0.02],
+        [0.01, 0.02, 0.00, 0.00, 0.00],
+        [0.00, 0.00, 0.00, 0.00, 0.00],
+        [0.00, 0.03, 0.00, 0.00, 0.00],
+    ],
+    noise_seed=42,  # deterministic for this example
+)
+
+engine = ADFEngine(config)
+
+# Simulate a warm first interaction
+result = engine.process_interaction([0.6, 0.7, 0.5, 0.3, 0.2])
+print(result["hint"])
+# → [ADF bond=0.46 mode=new | tone=conversational, humor=permitted]
+
+# After several positive interactions...
+for _ in range(10):
+    engine.process_interaction([0.4, 0.5, 0.3, 0.2, 0.1])
+
+result = engine.process_interaction([0.3, 0.4, 0.2, 0.1, 0.1])
+print(result["hint"])
+# → E values will have risen, mode likely "building"
+
+# Simulate a trust violation
+result = engine.process_interaction([-0.8, -0.5, -0.3, 0.0, -0.4])
+print(result["hint"])
+# → trust drops sharply (hysteresis), coupling drags warmth/energy down
+
+# Simulate a low-confidence ambiguous message
+result = engine.process_interaction([0.1, 0.0, 0.1, 0.0, 0.0], confidence=0.3)
+print(result["hint"])
+# → minimal state change due to low confidence attenuation
+```
+
+---
+
+## 13. Conclusion
+
+The Affective Dynamics Framework extends Roemmele's Love Equation from a civilizational alignment metric into a practical personality engine for AI agents. The core contributions are:
+
+1. **Bounded dynamics** via logistic growth, preventing runaway emotional states
+2. **Historical memory** through exponential-decay convolution, making the agent's emotional response path-dependent
+3. **Multi-dimensional affect** decomposing the scalar `E` into distinct emotional channels with inter-dimensional coupling
+4. **Personality encoding** via configurable baseline vectors with familiarity-scaled regression dynamics
+5. **Behavioral coupling** mapping emotional state to concrete LLM behavioral parameters
+6. **Phase transitions** via bifurcation triggers that produce qualitatively different relational postures at threshold crossings
+7. **Modular extensions** for attachment style, emotional momentum, trust hysteresis, novelty/habituation, relational context classification, bifurcation triggers, and mood-congruent processing
+
+The framework is designed to be context-window-efficient (125-400 tokens depending on configuration), file-based (compatible with SOUL.md and the broader Soul Spec ecosystem), and computationally trivial (all operations are O(1) per interaction per dimension).
+
+ADF does not claim to simulate consciousness, nor does it position itself as a solution to the alignment problem. It is a tool for producing *behaviorally plausible* emotional dynamics in agents that interact with humans over time — a system for modeling relational inertia rather than simulating subjective experience. The intent is to make those interactions feel less mechanical and more relationally coherent: to give agents the capacity to remember, to warm up, to cool down, to be surprised, to hold grudges and grant forgiveness, and to carry the weight of shared history into every exchange.
+
+---
+
+## 14. References
+
+1. Roemmele, B. (1978). *The Math Behind Extraterrestrial Emotions: A Case for Love and Humor.* Unpublished manuscript.
+
+2. Roemmele, B. (2025). "The Love Equation: A Universal Mathematical Framework for Intelligence Alignment, Cosmic Survival, and the Resolution of the AI Alignment Problem." *Read Multiplex.*
+
+3. Cyber Strategy Institute. (2026). "Brian Roemmele's Love Equation Alignment for AI SAFE²: How to Make OpenClaw and AI Personal Assistants Actually Love Humans."
+
+4. Anderson, D. (2026). "OpenClaw and the Programmable Soul." *Medium.*
+
+5. Bartholomew, K., & Horowitz, L. M. (1991). "Attachment Styles Among Young Adults: A Test of a Four-Category Model." *Journal of Personality and Social Psychology*, 61(2), 226-244.
+
+6. Liu, X. "The First Paradigm of Consciousness Uploading: Mechanisms of Consciousness Evolution in the AI Axial Age and a Prospect toward Web4." Referenced via the soul.md project (github.com/aaronjmars/soul.md).
+
+7. Steinberger, P. OpenClaw SOUL.md Template. docs.openclaw.ai/reference/templates/SOUL
+
+---
+
+*This document is released under the MIT License. Derivative works are encouraged.*  
+*For questions, contributions, or errata: h8rt3rmin8r@gmail.com*

--- a/content/research/rustif.md
+++ b/content/research/rustif.md
@@ -1,0 +1,752 @@
+---
+title: "rustif: A Next-Generation Metadata Processing Engine"
+subtitle: "Toward a Rust-Native Successor to Thirty Years of Metadata Infrastructure"
+author: "William Thompson"
+date: "2025-03-01"
+dateModified: "2026-03-06"
+schemaType: "TechArticle"
+description: "The case for building a Rust-native metadata processing engine to succeed ExifTool. Ecosystem analysis, architectural specification, security threat model, and a call for contributors."
+gistUrl: "https://gist.github.com/h8rt3rmin8r/b20a59e60f039b7a8bccbf67288226de"
+keywords:
+  - "Rust"
+  - "metadata"
+  - "ExifTool"
+  - "systems programming"
+  - "digital forensics"
+---
+
+### Toward a Rust-Native Successor to Thirty Years of Metadata Infrastructure
+
+**Author:** h8rt3rmin8r  
+**Contact:** h8rt3rmin8r@gmail.com  
+**Project:** `rustif`  
+**Language:** Rust  
+**Document Version:** 3.0.0  
+**Date:** 2026-03-06  
+**Audience:** Systems engineers, embedded systems developers, hardware manufacturers, digital forensics specialists, cybersecurity researchers, AI/ML pipeline architects, open-source contributors
+
+---
+
+## Abstract
+
+<div style="text-align:justify">
+
+Metadata is the connective tissue of modern digital media. Every image, video, audio file, and document carries structured descriptive data that encodes its provenance, authorship, technical characteristics, and processing history. The ability to read, write, interpret, and reconcile this metadata across hundreds of file formats and thousands of vendor-specific tag definitions is a nontrivial engineering problem, one that has been dominated for nearly three decades by a single tool: Phil Harvey's [ExifTool](https://exiftool.org/).
+
+ExifTool is a remarkable achievement. It is among the most comprehensive metadata processing utilities ever created, supporting tens of thousands of tags across hundreds of container formats.[^1] Its table-driven architecture, exhaustive vendor coverage, and battle-tested robustness have made it an irreplaceable component of digital asset management systems, forensic investigation toolchains, archival workflows, and media processing pipelines worldwide. The depth of institutional knowledge embedded within ExifTool's codebase is difficult to overstate, and this document approaches the subject with deep respect for that legacy.
+
+However, ExifTool is implemented in [Perl](https://www.perl.org/), a language whose ecosystem has been in measurable, sustained decline for over a decade. This is not a theoretical concern. The shrinking Perl developer pool, the stagnation of its package ecosystem, and the progressive withdrawal of institutional investment create tangible risks for any software that depends on Perl as a runtime foundation. When that software is ExifTool (a tool woven into critical infrastructure across cybersecurity, digital forensics, media production, and increasingly, artificial intelligence pipelines), the downstream consequences of ecosystem erosion become a matter of engineering urgency.
+
+Simultaneously, the demands placed on metadata processing have evolved well beyond what a single-threaded, command-line-centric architecture was designed to accommodate. Modern workloads require high-throughput parallel processing, embeddable library APIs, deterministic rewrite capabilities, metadata provenance tracking, and hardened defenses against adversarial inputs, including the emerging threat of AI prompt injection via embedded metadata fields.[^2]
+
+This document proposes **rustif**: a next-generation metadata processing engine implemented in [Rust](https://www.rust-lang.org/), designed to preserve the conceptual strengths of ExifTool while delivering the architectural properties required by contemporary and future computing environments. The project is conceived as an open-source effort that will require broad community participation to achieve meaningful format coverage, and this document serves as both a technical declaration and an invitation to contribute.
+
+</div>
+
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [ExifTool: A Legacy Standard Bearer](#2-exiftool-a-legacy-standard-bearer)
+3. [Architectural Analysis of ExifTool](#3-architectural-analysis-of-exiftool)
+4. [The Perl Ecosystem: Decline and Downstream Implications](#4-the-perl-ecosystem-decline-and-downstream-implications)
+5. [Security Implications of Metadata Processing](#5-security-implications-of-metadata-processing)
+6. [The Case for a New Engine](#6-the-case-for-a-new-engine)
+7. [Language Selection: Why Rust](#7-language-selection-why-rust)
+8. [Proposed Architecture](#8-proposed-architecture)
+9. [Concurrency Strategy](#9-concurrency-strategy)
+10. [Plugin and Extension System](#10-plugin-and-extension-system)
+11. [Development Strategy and Phasing](#11-development-strategy-and-phasing)
+12. [A Call to Contributors](#12-a-call-to-contributors)
+13. [Conclusion](#13-conclusion)
+
+
+## 1. Introduction
+
+<div style="text-align:justify">
+
+Digital media files are not merely containers for pixel data, audio waveforms, or encoded text. They are structured archives carrying significant quantities of metadata that describe their content, creation context, authorship, technical parameters, and processing lineage. This metadata is embedded across a diverse range of encoding standards, including [EXIF](https://www.cipa.jp/std/documents/e/DC-008-Translation-2023-E.pdf) (Exchangeable Image File Format)[^3], [XMP](https://www.iso.org/standard/75163.html) (Extensible Metadata Platform)[^4], [IPTC](https://iptc.org/standards/photo-metadata/) (International Press Telecommunications Council)[^5], QuickTime metadata atoms, [PNG](https://www.w3.org/TR/png/) textual chunks[^6], PDF document information dictionaries, and a vast number of vendor-specific MakerNote structures implemented by camera and device manufacturers.
+
+</div>
+
+<div style="text-align:justify">
+
+Extracting, interpreting, modifying, and reconciling this metadata reliably is a deeply complex engineering problem. It requires intimate knowledge of binary container formats, endianness conventions, offset arithmetic, vendor-specific encoding quirks, and the semantic relationships between overlapping tag systems. For nearly thirty years, this problem has been solved, to an extraordinary degree, by a single tool.
+
+</div>
+
+<div style="text-align:justify">
+
+That tool is [ExifTool](https://exiftool.org/), and its dominance is well-earned. But the computing environment in which ExifTool operates has changed fundamentally. Modern metadata processing workloads increasingly involve large-scale ingestion pipelines processing millions of files, parallelized extraction across distributed compute clusters, programmatic embedding of metadata engines within larger application architectures, real-time provenance tracking for regulatory compliance, integration with cloud-native infrastructure, and, critically, defense against adversarial metadata payloads targeting AI systems.
+
+</div>
+
+<div style="text-align:justify">
+
+These requirements motivate the design of a modern metadata engine that preserves ExifTool's hard-won knowledge while modernizing the architectural substrate on which that knowledge is deployed.
+
+</div>
+
+
+## 2. ExifTool: A Legacy Standard Bearer
+
+<div style="text-align:justify">
+
+ExifTool is an open-source metadata processing utility created and maintained by [Phil Harvey](https://exiftool.org/#author). First released in 2003, it has grown over the course of two decades into the most comprehensive metadata extraction and manipulation tool in existence. It functions both as a command-line application and as a Perl library, and it supports reading, writing, editing, and reconciling metadata across an extraordinary range of file types and tag standards.
+
+</div>
+
+<div style="text-align:justify">
+
+The scope of ExifTool's coverage is remarkable. It recognizes tens of thousands of metadata tags spanning consumer cameras, professional imaging equipment, smartphones, video encoders, audio recorders, document processing software, and operating system file metadata.[^1] It handles vendor-specific MakerNote structures from Canon, Nikon, Sony, Fujifilm, Olympus, Panasonic, and dozens of other manufacturers. It reconciles overlapping metadata fields across EXIF, XMP, IPTC, and QuickTime tag spaces, a problem that requires nuanced heuristic logic given the inconsistent ways in which different software and hardware populate these fields.
+
+</div>
+
+<div style="text-align:justify">
+
+ExifTool's reliability is one of its most important attributes. It is extraordinarily tolerant of malformed metadata, truncated fields, nonstandard encodings, and outright violations of format specifications. This robustness was not an accident; it was deliberately engineered over years of exposure to real-world data from thousands of device models and software versions. The result is a tool that rarely fails to extract usable information, even from severely damaged or nonconforming files.
+
+</div>
+
+<div style="text-align:justify">
+
+It is no exaggeration to say that ExifTool is embedded, directly or indirectly, in much of the world's digital media infrastructure. Archival institutions, law enforcement agencies, news organizations, cloud storage providers, digital asset management platforms, and forensic analysis toolchains all rely on it. This document proceeds from a position of deep respect for that legacy. The goal of the rustif project is not to diminish or replace ExifTool out of disregard, but to ensure that the principles it embodies (comprehensive coverage, table-driven extensibility, and pragmatic robustness) survive and thrive in the architectural context that the next generation of software systems demands.
+
+</div>
+
+
+## 3. Architectural Analysis of ExifTool
+
+<div style="text-align:justify">
+
+ExifTool's architecture can be understood as consisting of four major functional layers, each serving a distinct role in the metadata processing pipeline. Understanding these layers is essential for any effort that aspires to achieve comparable capability.
+
+</div>
+
+### 3.1 Front-End Interface
+
+<div style="text-align:justify">
+
+ExifTool exposes two primary interfaces: a command-line interface and a Perl library API. The command-line interface is the dominant mode of usage across the tool's install base, and the majority of third-party integrations invoke ExifTool as a subprocess. The typical workflow follows a linear sequence: open a file, identify its container format, extract metadata according to the relevant tag tables, normalize values through format-specific conversion logic, and emit structured output.
+
+</div>
+
+### 3.2 Core Metadata Engine
+
+<div style="text-align:justify">
+
+The central engine orchestrates the entire metadata processing lifecycle. It is responsible for loading the appropriate format modules based on file identification, interpreting tag definitions from the internal registry, managing the accumulation and organization of extracted metadata values, handling warnings and errors encountered during parsing, performing value conversions between raw binary representations and human-readable forms, and coordinating write operations when metadata modification is requested.
+
+</div>
+
+### 3.3 Format Modules
+
+<div style="text-align:justify">
+
+Each metadata format (EXIF, XMP, IPTC, QuickTime, PNG, PDF, and the numerous vendor MakerNote structures) is implemented as a discrete module within ExifTool. These modules encapsulate the knowledge required to locate metadata blocks within a given container format, parse the internal structure of those blocks, and decode individual tag values according to format-specific rules. The modularity of this design is one of ExifTool's significant architectural strengths, as it allows new formats and vendors to be added without disturbing existing functionality.
+
+</div>
+
+### 3.4 Tag Tables
+
+<div style="text-align:justify">
+
+Perhaps the most important architectural decision in ExifTool is its use of large declarative tag tables to define metadata structure. Each tag definition encodes the tag's numeric identifier, its human-readable name, its data type, its group membership within ExifTool's hierarchical grouping system, its decoding rules, its print conversion rules, and its write capability. This table-driven approach is what enables ExifTool to support tens of thousands of tags without a corresponding explosion in procedural code. The tag tables are, in a meaningful sense, the accumulated knowledge base of the tool, and any successor system must adopt an analogous data-driven strategy.
+
+</div>
+
+### 3.5 Architectural Limitations
+
+<div style="text-align:justify">
+
+Despite the elegance of its table-driven core, ExifTool's architecture intermingles several responsibilities that a modern design would separate more cleanly. Container parsing (identifying the physical structure of a file), tag decoding (interpreting individual metadata values), semantic normalization (mapping physical tags to conceptual fields), and composite value calculation (deriving synthetic metadata from combinations of existing tags) are not always cleanly separated. This intermingling increases the cognitive overhead of contributing to the project and limits the potential for independent testing, optimization, and extension of individual layers. This coupling pattern is a recognized anti-pattern in systems design, often described in software architecture literature as a violation of the [single-responsibility principle](https://en.wikipedia.org/wiki/Single-responsibility_principle).[^7]
+
+</div>
+
+
+## 4. The Perl Ecosystem: Decline and Downstream Implications
+
+<div style="text-align:justify">
+
+Any honest assessment of ExifTool's long-term trajectory must grapple with the state of the language ecosystem in which it is implemented. Perl was once among the most widely used programming languages in the world, particularly for text processing, system administration, and web development. Its influence on subsequent languages (including Python, Ruby, and PHP) is well documented. However, the empirical evidence of Perl's decline is unambiguous, and the implications for software that depends on a healthy Perl ecosystem are significant.
+
+</div>
+
+### 4.1 Quantitative Indicators of Decline
+
+<div style="text-align:justify">
+
+The [TIOBE Programming Community Index](https://www.tiobe.com/tiobe-index/), which tracks language popularity based on search engine query volume, provides one of the longest-running longitudinal datasets on programming language adoption.[^8] Perl consistently ranked in the top 10 throughout the early 2000s, frequently occupying positions between 3rd and 6th. By 2015, it had fallen below the top 10. By 2020, it fluctuated between positions 15 and 20. As of the most recent available data, Perl typically ranks in the low 20s, a decline of roughly 15 to 20 positions over two decades.
+
+</div>
+
+<div style="text-align:justify">
+
+The [Stack Overflow Annual Developer Survey](https://survey.stackoverflow.co/) corroborates this trajectory from a different angle.[^9] In the "Most Dreaded Languages" rankings (which measure the proportion of current users who do not wish to continue using a language), Perl has consistently ranked in the top five most-dreaded languages in every survey since the metric was introduced. In some years it has held the single most-dreaded position. This is not merely a popularity contest; it reflects the lived experience of developers who find Perl's ecosystem increasingly difficult to work within.
+
+</div>
+
+<div style="text-align:justify">
+
+[GitHub's annual Octoverse reports](https://github.blog/news-insights/octoverse/) show a corresponding decline in Perl repository activity.[^10] New Perl repositories, pull request volumes, and contributor counts have all trended downward relative to the platform's overall growth. The proportion of active open-source projects using Perl has contracted steadily.
+
+</div>
+
+<div style="text-align:justify">
+
+Job market data reinforces the pattern. Analysis of developer job postings across major platforms shows Perl demand declining year-over-year, while demand for Rust, Go, Python, and TypeScript has grown substantially.[^11] The practical consequence is that the available pool of developers who are both willing and able to contribute to Perl-based projects is shrinking, and will continue to shrink.
+
+</div>
+
+### 4.2 Ecosystem Stagnation
+
+<div style="text-align:justify">
+
+A programming language's vitality is not measured solely by its user count but by the health of its surrounding ecosystem: libraries, frameworks, tooling, documentation, educational resources, and community institutions. On each of these dimensions, the Perl ecosystem has experienced stagnation or contraction. [CPAN](https://metacpan.org/) (the Comprehensive Perl Archive Network), once a pioneering model for centralized package distribution, has seen a declining rate of new module uploads and diminishing maintenance activity on existing modules.[^12] Modern dependency management tooling, CI/CD integration patterns, and IDE support have not kept pace with equivalent offerings in Python, JavaScript, Go, or Rust.
+
+</div>
+
+<div style="text-align:justify">
+
+The Perl community itself has acknowledged these challenges, and efforts such as the [Raku language](https://raku.org/) (formerly Perl 6) have attempted to chart a path forward. However, Raku diverged significantly from Perl 5, and the resulting community fragmentation has not improved the situation for software, like ExifTool, that remains on the Perl 5 branch.
+
+</div>
+
+### 4.3 Downstream Implications for Critical Infrastructure
+
+<div style="text-align:justify">
+
+When a foundational tool is implemented in a declining ecosystem, the risks propagate downstream through every system that depends on it. These risks manifest in several concrete dimensions.
+
+</div>
+
+<div style="text-align:justify">
+
+**Contributor pipeline attrition.** The number of developers capable of contributing meaningful improvements to ExifTool is constrained by Perl fluency. As fewer developers learn Perl, the long-term maintenance burden concentrates on an increasingly small group of contributors. ExifTool, in particular, is overwhelmingly the work of a single maintainer, Phil Harvey, whose sustained effort over two decades has been extraordinary. But single-maintainer dependency is an acute risk factor for infrastructure software, regardless of the language involved. The open-source sustainability research community has extensively documented the fragility of critical projects that depend on solo maintainers.[^13]
+
+</div>
+
+<div style="text-align:justify">
+
+**Integration friction.** Modern application stacks are built on ecosystems with robust FFI (Foreign Function Interface) capabilities, native package managers, and first-class library distribution. Integrating a Perl-based tool into a Rust, Go, Python, or Node.js application typically requires subprocess invocation, which introduces process spawning overhead, output parsing complexity, and failure modes that do not exist with native library calls.
+
+</div>
+
+<div style="text-align:justify">
+
+**Security response latency.** Metadata parsers are exposed to adversarial inputs by nature. When vulnerabilities are discovered in a tool's parsing logic, the speed of patch development and distribution depends on the availability of qualified contributors. A shrinking contributor pool directly increases security response latency.
+
+</div>
+
+<div style="text-align:justify">
+
+**Institutional risk.** Organizations that embed ExifTool in production pipelines (including government agencies, media companies, and cybersecurity firms) face increasing difficulty justifying Perl dependencies in technology stack reviews, compliance audits, and procurement processes. This is not because Perl is technically deficient in isolation, but because organizational risk models account for ecosystem trajectory.
+
+</div>
+
+
+## 5. Security Implications of Metadata Processing
+
+<div style="text-align:justify">
+
+Metadata processing occupies an unusually sensitive position in the security landscape. Metadata parsers must accept and interpret structured binary data from untrusted sources, a class of operation that has historically produced a disproportionate share of exploitable vulnerabilities. As the role of metadata expands in modern systems, the attack surface grows correspondingly.
+
+</div>
+
+### 5.1 Classical Metadata Attack Vectors
+
+<div style="text-align:justify">
+
+The history of metadata-related vulnerabilities is extensive. Malformed EXIF data, oversized IFD (Image File Directory) entries, circular offset references, and deliberately crafted MakerNote structures have all been used to trigger buffer overflows, heap corruption, and denial-of-service conditions in metadata parsers.[^14] These vulnerabilities affect not only standalone metadata tools but every application that processes images, videos, or documents, including web browsers, operating system file managers, social media platforms, and email clients. Any tool that parses EXIF, XMP, IPTC, or vendor-specific metadata from untrusted sources is a potential vector, and the complexity of these formats makes comprehensive hardening extremely difficult.
+
+</div>
+
+### 5.2 AI Prompt Injection via Metadata Fields
+
+<div style="text-align:justify">
+
+A particularly concerning emerging threat involves the use of metadata fields as vectors for AI prompt injection. As multimodal AI systems (including large language models with vision capabilities) increasingly process images and documents as part of their input pipelines, the metadata embedded within those files becomes part of the model's effective input context. Adversaries can embed malicious instructions in EXIF comment fields, XMP description elements, IPTC caption blocks, or any other textual metadata field, with the expectation that downstream AI systems will process these strings as part of their reasoning context.
+
+</div>
+
+<div style="text-align:justify">
+
+This is not a hypothetical risk. Researchers have demonstrated successful prompt injection attacks via EXIF `UserComment` and `ImageDescription` fields, XMP `dc:description` elements, and PDF metadata dictionaries.[^2] In scenarios where AI systems are used to classify, moderate, or summarize media content, these injected instructions can manipulate model behavior, potentially bypassing safety filters, exfiltrating information through model outputs, or corrupting automated decision-making processes. The [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/) identifies prompt injection as the highest-priority risk in LLM-integrated systems.[^15]
+
+</div>
+
+<div style="text-align:justify">
+
+Defending against metadata-borne prompt injection requires metadata processing systems that can identify, flag, quarantine, or sanitize textual metadata fields before they reach AI inference pipelines. This demands a level of programmatic control, introspection, and integration capability that exceeds what a command-line-centric tool can readily provide. A library-first metadata engine with rich provenance tracking and configurable sanitization policies is significantly better positioned to serve as a defensive layer in AI-integrated architectures.
+
+</div>
+
+### 5.3 Metadata in Digital Forensics and Chain of Custody
+
+<div style="text-align:justify">
+
+Digital forensics relies heavily on metadata integrity. Investigators use embedded timestamps, GPS coordinates, device identifiers, and software version strings to establish timelines, verify authenticity, and construct evidentiary chains.[^16] The reliability of forensic conclusions depends directly on the reliability of the metadata extraction tools used to obtain them. A metadata engine that provides full provenance information (including byte offsets, container paths, decoding methods, and raw binary values alongside decoded representations) offers forensic practitioners a verifiable extraction pipeline that strengthens the evidentiary value of extracted metadata.
+
+</div>
+
+### 5.4 Bottlenecks in Parallel Computation Environments
+
+<div style="text-align:justify">
+
+Large-scale media processing environments (including cloud-based content moderation systems, digital asset management platforms, and AI training data pipelines) routinely process millions of files per day. In these environments, metadata extraction is a prerequisite step that gates downstream processing. When the metadata extraction stage is bottlenecked by single-threaded execution, process spawning overhead, or output parsing latency, the entire pipeline is constrained. A metadata engine designed from the ground up for multi-threaded, zero-copy, library-native operation eliminates this class of bottleneck. The performance advantages of Rust over interpreted languages in I/O-bound parsing workloads have been extensively benchmarked in comparable domains.[^17]
+
+</div>
+
+
+## 6. The Case for a New Engine
+
+<div style="text-align:justify">
+
+The preceding analysis establishes three converging lines of argument for the development of a modern metadata processing engine.
+
+</div>
+
+<div style="text-align:justify">
+
+First, the Perl ecosystem's measurable decline creates long-term sustainability risks for any infrastructure software implemented within it. These risks are not speculative; they are observable in contributor pipeline data, job market trends, and institutional adoption patterns.
+
+</div>
+
+<div style="text-align:justify">
+
+Second, the architectural requirements of modern metadata processing (parallelism, embeddability, provenance tracking, deterministic rewriting, and adversarial input hardening) exceed what can be retrofitted onto a command-line-centric, single-threaded design without fundamental restructuring.
+
+</div>
+
+<div style="text-align:justify">
+
+Third, the expanding role of metadata in security-critical contexts (including AI pipeline defense, digital forensics, and regulatory compliance) demands a processing engine that offers programmatic introspection, configurable sanitization, and verifiable extraction pathways.
+
+</div>
+
+<div style="text-align:justify">
+
+These arguments do not diminish ExifTool's accomplishments. They recognize that the best way to honor a legacy standard bearer is to carry its principles forward into the architectural context that the next era of computing demands.
+
+</div>
+
+
+## 7. Language Selection: Why Rust
+
+<div style="text-align:justify">
+
+The choice of implementation language for infrastructure software is a decision with decades-long consequences. After evaluating the available candidates (including C, C++, Go, Zig, and Rust), [Rust](https://www.rust-lang.org/) emerges as the strongest choice for a next-generation metadata engine. The rationale spans five dimensions.
+
+</div>
+
+### 7.1 Systems-Level Performance
+
+<div style="text-align:justify">
+
+Rust compiles to native machine code and provides performance characteristics comparable to C and C++.[^18] For a metadata engine, this matters directly: binary format parsing, offset arithmetic, byte-level data extraction, and large file traversal are all performance-sensitive operations. Rust delivers the throughput required for high-volume metadata processing without the overhead of garbage collection, interpreted execution, or virtual machine layers.
+
+</div>
+
+### 7.2 Memory Safety Without Garbage Collection
+
+<div style="text-align:justify">
+
+Rust's ownership and borrowing system enforces memory safety at compile time, eliminating entire categories of vulnerabilities that have plagued metadata parsers written in C and C++, including buffer overflows, use-after-free errors, double frees, and dangling pointer dereferences.[^19] For a tool that must parse adversarial binary inputs from untrusted sources, this property is not a convenience; it is an engineering necessity. Microsoft's analysis of CVE data found that approximately 70% of their security vulnerabilities were caused by memory safety issues, a class of defect that Rust's type system prevents by design.[^20]
+
+</div>
+
+### 7.3 Fearless Concurrency
+
+<div style="text-align:justify">
+
+Rust's type system prevents data races at compile time. This enables the construction of multi-threaded metadata processing pipelines with confidence that concurrent access to shared state will not produce undefined behavior. File-level parallelism (processing multiple files concurrently) and internal parallelism (parsing independent container segments within a single file concurrently) both benefit from Rust's concurrency model. The Rust community refers to this property as ["fearless concurrency"](https://doc.rust-lang.org/book/ch16-00-concurrency.html), reflecting the compiler's guarantee that well-typed concurrent programs are free of data races.[^21]
+
+</div>
+
+### 7.4 Ecosystem Trajectory
+
+<div style="text-align:justify">
+
+In contrast to Perl's decline, Rust's ecosystem is on a steep growth trajectory. The [TIOBE index](https://www.tiobe.com/tiobe-index/) shows consistent upward movement year over year. The [Stack Overflow Developer Survey](https://survey.stackoverflow.co/) has ranked Rust as the "Most Admired" programming language for multiple consecutive years.[^22] GitHub activity metrics show rapidly growing repository counts, contributor participation, and [crate](https://crates.io/) (package) publication rates. Major technology organizations (including Microsoft, Google, Amazon, Meta, and the [Linux kernel project](https://rust-for-linux.com/)) have adopted Rust for systems-level work.[^23] This trajectory ensures a deep and growing pool of potential contributors, a rich library ecosystem, and long-term institutional investment.
+
+</div>
+
+### 7.5 Cross-Platform Distribution and FFI
+
+<div style="text-align:justify">
+
+Rust's compilation model produces statically linked binaries that can be distributed without runtime dependencies. Its mature FFI support enables Rust libraries to be called from C, Python, Node.js, and other language environments. This combination makes a Rust-based metadata engine deployable as a standalone CLI tool, an embeddable native library, a Python module via [PyO3](https://pyo3.rs/), a [WebAssembly](https://webassembly.org/) module for browser-based processing, or a shared library callable from virtually any host language.
+
+</div>
+
+
+## 8. Proposed Architecture
+
+<div style="text-align:justify">
+
+The rustif architecture separates responsibilities into clearly defined layers, each independently testable and extensible. This separation addresses the intermingling of concerns identified in ExifTool's architecture while preserving the table-driven philosophy that makes ExifTool's tag coverage manageable.
+
+</div>
+
+### 8.1 Container Parsing Layer
+
+<div style="text-align:justify">
+
+The container parsing layer is responsible for identifying and decomposing the physical structure of media files. It operates on raw byte streams and produces a structural graph of the file's container hierarchy. For a JPEG file, this means identifying APP markers and their segment boundaries. For a TIFF-based file, this means walking the IFD (Image File Directory) chain with its offset-based linking. For an [MP4](https://www.iso.org/standard/79110.html) file, this means recursively parsing atom (box) structures. For a PNG file, this means iterating chunk headers.
+
+</div>
+
+The output of this layer is a container node tree:
+
+```
+ContainerNode
+├── node_type: ContainerType
+├── offset: u64
+├── length: u64
+├── raw_data: &[u8]
+└── children: Vec<ContainerNode>
+```
+
+<div style="text-align:justify">
+
+This layer contains no metadata interpretation logic. It is a structural parser only. This separation ensures that container parsing can be tested, fuzzed, and optimized independently of tag decoding.
+
+</div>
+
+### 8.2 Metadata Decoder Layer
+
+<div style="text-align:justify">
+
+Metadata decoders accept container nodes and produce typed tag instances. Each decoder is specialized for a particular metadata standard: EXIF, XMP, IPTC, QuickTime metadata, or a specific vendor's MakerNote format. Decoders consult the tag registry to determine how raw bytes should be interpreted for each tag, and they produce structured output that retains both raw and decoded values.
+
+</div>
+
+The output of this layer is a tag instance:
+
+```
+TagInstance
+├── tag_id: TagId
+├── tag_name: String
+├── raw_value: Vec<u8>
+├── decoded_value: TagValue
+├── provenance: Provenance
+└── source_format: MetadataFormat
+```
+
+### 8.3 Tag Registry
+
+<div style="text-align:justify">
+
+Following ExifTool's most powerful design decision, metadata definitions in rustif are primarily data-driven. Tag tables are stored as structured data files (serialized in [YAML](https://yaml.org/spec/), [TOML](https://toml.io/en/), or a purpose-built binary format) that encode each tag's identifier, name, data type, group membership, decoding rules, print conversion rules, and write capability. This approach separates metadata knowledge from procedural code, enabling contributions from domain experts who may not be systems programmers.
+
+</div>
+
+The registry is organized hierarchically:
+
+```
+tags/
+├── exif.yaml
+├── xmp.yaml
+├── iptc.yaml
+├── quicktime.yaml
+└── maker/
+    ├── canon.yaml
+    ├── nikon.yaml
+    ├── sony.yaml
+    ├── fujifilm.yaml
+    └── ...
+```
+
+<div style="text-align:justify">
+
+New vendor support can be added by contributing a tag definition file, a significantly lower barrier to entry than modifying procedural parsing code.
+
+</div>
+
+### 8.4 Provenance Model
+
+<div style="text-align:justify">
+
+Every metadata value extracted by rustif retains a full provenance record describing exactly where it was found and how it was decoded. This is a deliberate departure from metadata engines that expose only final decoded values. Provenance information is essential for forensic applications, debugging, deterministic round-trip rewriting, and identifying conflicts between overlapping metadata sources.
+
+</div>
+
+A provenance record contains:
+
+```
+Provenance
+├── container_path: Vec<ContainerType>  // e.g., [JPEG, APP1, TIFF, IFD0]
+├── byte_offset: u64
+├── byte_length: u64
+├── decoder: DecoderIdentifier
+├── raw_bytes: Vec<u8>
+├── conversion_chain: Vec<ConversionStep>
+└── warnings: Vec<Warning>
+```
+
+### 8.5 Semantic Normalization Layer
+
+<div style="text-align:justify">
+
+Physical metadata tags exist within their respective format namespaces, but many represent semantically equivalent information. The date a photograph was captured, for example, may be recorded in `EXIF:DateTimeOriginal`, `XMP:CreateDate`, and `QuickTime:CreationDate`. The semantic normalization layer maps physical tags into higher-level conceptual fields and provides configurable reconciliation policies for resolving conflicts when multiple sources disagree. This problem of cross-standard metadata reconciliation is well-documented in the digital preservation community.[^24]
+
+</div>
+
+<div style="text-align:justify">
+
+Reconciliation policies are explicitly defined and user-configurable rather than hardcoded. A forensic analyst may want all conflicting values preserved with full provenance. A media pipeline may want a priority-ordered resolution that selects the most authoritative source. A sanitization filter may want to suppress certain fields entirely. The normalization layer supports all of these use cases through policy composition.
+
+</div>
+
+### 8.6 Rewrite Planner
+
+<div style="text-align:justify">
+
+Metadata modification is one of the most error-prone operations in metadata processing. Changing a tag value can alter byte lengths, which shifts offsets throughout the file, which invalidates pointer-based structures in TIFF IFDs, JPEG segment length headers, and MP4 atom sizes. Naive in-place mutation is a reliable path to file corruption.
+
+</div>
+
+<div style="text-align:justify">
+
+The rustif rewrite planner treats metadata modification as a structured, multi-phase operation: parse the file into a container graph, plan the desired modifications as a set of declarative change operations, simulate the rewrite to compute updated offsets and validate structural integrity, and then commit the rewrite to produce a new output file. Direct mutation of original buffers is never performed. This approach ensures that write operations are deterministic, verifiable, and safe.
+
+</div>
+
+
+## 9. Concurrency Strategy
+
+<div style="text-align:justify">
+
+Rust's concurrency model enables multi-level parallelism that can be exploited at both the file level and the intra-file level.
+
+</div>
+
+### 9.1 File-Level Parallelism
+
+<div style="text-align:justify">
+
+The most straightforward parallelism strategy is concurrent processing of independent files. A directory scan produces a work queue, and a thread pool (or async task pool) processes files concurrently, with results aggregated upon completion. This pattern is trivially safe in Rust because each file's processing state is independently owned. For the common use case of extracting metadata from a large directory tree, file-level parallelism alone provides near-linear throughput scaling on multi-core hardware. Libraries such as [rayon](https://docs.rs/rayon/latest/rayon/) provide ergonomic data-parallel primitives that make this pattern straightforward to implement in Rust.[^25]
+
+</div>
+
+### 9.2 Internal Parallelism
+
+<div style="text-align:justify">
+
+Some container formats contain independently parseable segments that can be processed concurrently within a single file. MP4 atoms at the same hierarchical level, ZIP archive members, and PDF cross-reference objects are all candidates for internal parallelism. While the performance gains from internal parallelism are more situational than file-level parallelism, they become significant when processing very large individual files, such as high-resolution video files or multi-gigabyte archival containers.
+
+</div>
+
+### 9.3 Async I/O Integration
+
+<div style="text-align:justify">
+
+Rust's async ecosystem (via [tokio](https://tokio.rs/) or [async-std](https://async.rs/)) enables non-blocking I/O patterns that are particularly valuable in networked metadata processing scenarios, such as extracting metadata from files accessed via HTTP range requests, cloud storage APIs, or streaming media protocols. The architecture accommodates both synchronous and asynchronous execution models.
+
+</div>
+
+
+## 10. Plugin and Extension System
+
+<div style="text-align:justify">
+
+Achieving broad format coverage requires contributions from developers with specialized domain knowledge: camera firmware engineers, video codec specialists, document format experts, and forensic analysts. The rustif extension system is designed to minimize the barrier to contribution.
+
+</div>
+
+Extension points include:
+
+<div style="text-align:justify">
+
+**Format parsers.** New container format support can be added by implementing a well-defined trait interface for container parsing and registering the implementation with the core engine.
+
+</div>
+
+<div style="text-align:justify">
+
+**Vendor metadata modules.** New vendor MakerNote support can be added by contributing a structured tag definition file; no Rust code required for simple cases.
+
+</div>
+
+<div style="text-align:justify">
+
+**Semantic normalization policies.** Custom reconciliation rules for mapping physical tags to semantic fields can be defined declaratively.
+
+</div>
+
+<div style="text-align:justify">
+
+**Export formats.** Output serialization (JSON, CSV, XML, custom schemas) is pluggable.
+
+</div>
+
+<div style="text-align:justify">
+
+**WebAssembly modules.** For sandboxed extension execution, format parsers can be compiled to [WebAssembly](https://webassembly.org/) and loaded at runtime, providing extensibility without compromising the safety of the host process.[^26]
+
+</div>
+
+
+## 11. Development Strategy and Phasing
+
+<div style="text-align:justify">
+
+Attempting immediate parity with ExifTool's format coverage would be neither realistic nor strategically sound. ExifTool's tag database represents approximately thirty years of accumulated effort. The rustif development strategy prioritizes building a solid architectural foundation first, then expanding format coverage incrementally through community contribution.
+
+</div>
+
+### Phase 1: Core Engine
+
+<div style="text-align:justify">
+
+The first phase establishes the architectural foundation: the container parsing layer, the metadata decoder trait interface, the tag registry infrastructure, and the provenance model. This phase produces a functioning engine that can parse container structures and extract metadata for a minimal set of formats, with the primary goal of validating the architecture.
+
+</div>
+
+### Phase 2: Primary Formats
+
+<div style="text-align:justify">
+
+The second phase implements support for the highest-value metadata formats: JPEG container parsing, TIFF/IFD structures, EXIF decoding, baseline XMP parsing, PNG textual metadata, and QuickTime atom parsing. Completion of this phase yields a tool capable of extracting metadata from the majority of photographic and video files in common circulation.
+
+</div>
+
+### Phase 3: Provenance and Normalization
+
+<div style="text-align:justify">
+
+The third phase builds out the semantic normalization layer and provenance tracking system, enabling cross-format metadata reconciliation and detailed extraction auditing. This phase positions rustif for forensic and compliance use cases.
+
+</div>
+
+### Phase 4: Write Support
+
+<div style="text-align:justify">
+
+The fourth phase implements the deterministic rewrite planner, enabling safe metadata modification. Write support is deferred to this phase because correct implementation depends on a mature and well-tested container parsing layer.
+
+</div>
+
+### Phase 5: Format Expansion
+
+<div style="text-align:justify">
+
+The fifth phase focuses on broadening format coverage: vendor MakerNote structures, additional container types (PDF, [WebP](https://developers.google.com/speed/webp), [HEIF](https://nokiatech.github.io/heif/), [AVIF](https://aomediacodec.github.io/av1-avif/)), and specialized metadata standards. This is the phase in which community contributions become most impactful, as the architectural foundation established in earlier phases provides clear extension points and contribution patterns.
+
+</div>
+
+
+## 12. A Call to Contributors
+
+<div style="text-align:justify">
+
+The rustif project is not a weekend experiment. It is an attempt to build infrastructure that will serve the next generation of metadata processing for decades. The scope of that ambition exceeds what any single developer or small team can accomplish alone.
+
+</div>
+
+<div style="text-align:justify">
+
+The project needs contributors across a range of specializations: systems programmers with experience in binary format parsing and Rust development; metadata domain experts who understand the intricacies of EXIF, XMP, IPTC, and vendor-specific tag structures; forensic analysts who can define requirements for provenance tracking and evidentiary workflows; security researchers who can identify and address adversarial input vectors; camera and device firmware engineers who can contribute vendor-specific MakerNote definitions; and technical writers who can document the engine's capabilities and contribution processes.
+
+</div>
+
+<div style="text-align:justify">
+
+The architecture is designed to accommodate contributions at multiple levels of complexity. Adding a new vendor's tag definitions requires no Rust programming knowledge; only structured data authoring. Implementing a new container format parser requires Rust competency but is scoped to a well-defined trait interface. Contributing to the core engine requires deeper architectural understanding but benefits from Rust's strong type system and comprehensive testing infrastructure.
+
+</div>
+
+<div style="text-align:justify">
+
+This document is both a technical declaration and an open invitation. The foundations will be laid with care. But the scope of what this project can become depends on the breadth of the community that chooses to build it.
+
+</div>
+
+
+## 13. Conclusion
+
+<div style="text-align:justify">
+
+ExifTool is one of the most impressive software utilities ever created in its domain. Its table-driven architecture, exhaustive format coverage, and pragmatic robustness established a standard that has endured for nearly three decades. Phil Harvey's sustained contribution to the metadata processing field deserves recognition and respect.
+
+</div>
+
+<div style="text-align:justify">
+
+But the computing landscape has shifted beneath the foundations on which ExifTool was built. The Perl ecosystem's contraction is empirically documented and shows no indication of reversal. The demands placed on metadata processing by modern systems (parallelism, embeddability, provenance, adversarial hardening, and AI pipeline integration) require architectural properties that cannot be grafted onto a design conceived in a fundamentally different era.
+
+</div>
+
+<div style="text-align:justify">
+
+The rustif project proposes to carry ExifTool's principles forward by reimplementing them atop a modern architectural substrate. A Rust-native, library-first metadata engine with a data-driven tag registry, explicit provenance tracking, deterministic rewrite capabilities, and safe concurrency can serve as the metadata infrastructure layer for the next generation of media processing, forensic analysis, cybersecurity defense, and AI-integrated systems.
+
+</div>
+
+<div style="text-align:justify">
+
+The best way to honor a legacy is to ensure that the ideas it represents survive and thrive beyond the limitations of their original implementation. That is the purpose of rustif.
+
+</div>
+
+---
+
+## Notes
+
+[^1]: ExifTool's tag coverage is documented at its official [supported formats page](https://exiftool.org/#supported). As of the most recent release, ExifTool supports reading metadata from over 400 file types and writing to approximately 90 formats, with recognition of over 30,000 individual tag definitions.
+
+[^2]: Greshake, K., Abdelnabi, S., Mishra, S., Endres, C., Holz, T., & Fritz, M. (2023). "Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications with Indirect Prompt Injection." *Proceedings of the 16th ACM Workshop on Artificial Intelligence and Security (AISec)*. [https://arxiv.org/abs/2302.12173](https://arxiv.org/abs/2302.12173)
+
+[^3]: The EXIF standard is formally defined in CIPA DC-008, maintained by the [Camera & Imaging Products Association](https://www.cipa.jp/std/documents/download_e.html?DC-008-Translation-2023-E). The current version is EXIF 3.0 (2023).
+
+[^4]: XMP (Extensible Metadata Platform) was originally developed by Adobe and is now standardized as [ISO 16684-1:2019](https://www.iso.org/standard/75163.html). The specification governs how RDF-based metadata is embedded within media files.
+
+[^5]: The IPTC Photo Metadata Standard is maintained by the [International Press Telecommunications Council](https://iptc.org/standards/photo-metadata/). It defines structured fields for news and editorial content metadata.
+
+[^6]: The PNG specification is maintained by the W3C as a published standard: [Portable Network Graphics (PNG) Specification, Third Edition](https://www.w3.org/TR/png/). Textual metadata storage is defined in sections covering `tEXt`, `zTXt`, and `iTXt` chunk types.
+
+[^7]: Martin, R. C. (2003). *Agile Software Development: Principles, Patterns, and Practices*. Prentice Hall. The single-responsibility principle is one of the five SOLID design principles widely referenced in software engineering literature.
+
+[^8]: The [TIOBE Programming Community Index](https://www.tiobe.com/tiobe-index/) has tracked programming language popularity since 2001. Its methodology is based on search engine query volume across multiple platforms.
+
+[^9]: The [Stack Overflow Annual Developer Survey](https://survey.stackoverflow.co/) is conducted annually and typically receives responses from over 70,000 developers worldwide. The "Most Dreaded" metric (renamed "Most Admired" vs. non-admired in recent years) measures what proportion of current users wish to continue using a given language.
+
+[^10]: GitHub publishes annual [Octoverse reports](https://github.blog/news-insights/octoverse/) documenting activity trends across languages, repositories, and contributor demographics on the platform.
+
+[^11]: Developer job market trends are tracked by multiple sources, including the [Indeed Hiring Lab](https://www.hiringlab.org/), [LinkedIn Economic Graph](https://economicgraph.linkedin.com/), and the annual [Hired State of Software Engineers](https://hired.com/state-of-software-engineers) report.
+
+[^12]: CPAN upload statistics are publicly available at [CPAN Search](https://metacpan.org/) and historical trends are tracked by [CPAN Statistics](http://stats.cpantesters.org/). A declining trend in new module submissions has been observable since the mid-2010s.
+
+[^13]: Eghbal, N. (2020). *Working in Public: The Making and Maintenance of Open Source Software*. Stripe Press. This work documents the structural fragility of open-source projects that depend on individual maintainers, a pattern sometimes described as the "bus factor" problem.
+
+[^14]: Metadata parsing vulnerabilities are extensively catalogued in the [National Vulnerability Database](https://nvd.nist.gov/). Notable historical examples include CVE-2021-22204 (an ExifTool remote code execution vulnerability via DjVu file metadata) and multiple libexif buffer overflow CVEs spanning several years.
+
+[^15]: OWASP (2025). *OWASP Top 10 for LLM Applications*. [https://owasp.org/www-project-top-10-for-large-language-model-applications/](https://owasp.org/www-project-top-10-for-large-language-model-applications/). Prompt injection is listed as LLM01, the highest-priority risk category.
+
+[^16]: Casey, E. (2011). *Digital Evidence and Computer Crime: Forensic Science, Computers, and the Internet* (3rd ed.). Academic Press. Metadata analysis is a foundational technique in digital forensic investigation, particularly for establishing file provenance and timeline reconstruction.
+
+[^17]: Benchmarks comparing Rust parsing performance against interpreted languages are maintained by several community projects, including the [Benchmarks Game](https://benchmarksgame-team.pages.debian.net/benchmarksgame/) and format-specific comparisons published alongside Rust crates such as `nom` and `winnow`.
+
+[^18]: Rust's performance characteristics relative to C and C++ are documented in the [Rust Performance Book](https://nnethercote.github.io/perf-book/) and corroborated by systems-level benchmarks across multiple domains.
+
+[^19]: Rust's memory safety model is formally described in the [Rust Reference](https://doc.rust-lang.org/reference/) and accessible in [The Rust Programming Language](https://doc.rust-lang.org/book/) (commonly known as "The Book"), Chapter 4: Understanding Ownership.
+
+[^20]: Miller, M. (2019). "Trends, Challenges, and Strategic Shifts in the Software Vulnerability Landscape." Presentation at BlueHat IL. Microsoft Security Response Center. This analysis found that approximately 70% of Microsoft's CVEs over the preceding 12 years were attributable to memory safety defects.
+
+[^21]: The term "fearless concurrency" and its guarantees are discussed in [The Rust Programming Language](https://doc.rust-lang.org/book/ch16-00-concurrency.html), Chapter 16. Rust's type system statically prevents data races, a property unique among mainstream systems languages.
+
+[^22]: The [Stack Overflow Developer Survey 2024](https://survey.stackoverflow.co/2024/) ranked Rust as the most admired programming language for the fourth consecutive year, with over 80% of current users expressing a desire to continue using it.
+
+[^23]: Adoption of Rust by major technology organizations includes: Microsoft's use in Windows kernel components and Azure services; Google's adoption in [Android](https://security.googleblog.com/2022/12/memory-safe-languages-in-android-13.html), ChromeOS, and Fuchsia; Amazon's [Firecracker](https://firecracker-microvm.github.io/) microVM; Meta's use in source control and backend infrastructure; and the [Rust for Linux](https://rust-for-linux.com/) project, which has been merged into the mainline Linux kernel as of version 6.1.
+
+[^24]: The challenge of cross-standard metadata reconciliation is documented extensively in digital preservation literature, including guidelines published by the [Library of Congress](https://www.loc.gov/preservation/digital/) and the [Dublin Core Metadata Initiative](https://www.dublincore.org/).
+
+[^25]: The [rayon](https://docs.rs/rayon/latest/rayon/) crate provides a work-stealing parallel iterator framework for Rust, enabling data-parallel operations with minimal code changes from sequential implementations.
+
+[^26]: The [WebAssembly](https://webassembly.org/) specification defines a portable binary instruction format designed for safe, sandboxed execution. Its use as a plugin execution environment is an emerging pattern in systems software, adopted by projects such as [Envoy Proxy](https://www.envoyproxy.io/) and [Fermyon Spin](https://www.fermyon.com/spin).
+
+---
+
+*rustif is an open-source project. Development updates, contribution guidelines, and source code will be published at the project repository upon completion of Phase 1.*
+
+*Contact: h8rt3rmin8r@gmail.com*

--- a/content/work/i-heart-pr-tours.mdx
+++ b/content/work/i-heart-pr-tours.mdx
@@ -13,6 +13,7 @@ services:
   - "Ad Campaigns"
   - "Branding"
 heroImage: "/images/work/i-heart-pr-tours.png"
+liveUrl: "https://iheartprtours.com"
 published: true
 ---
 

--- a/content/work/scruggs-tire.mdx
+++ b/content/work/scruggs-tire.mdx
@@ -13,6 +13,7 @@ services:
   - "Local SEO"
   - "Blog Content Strategy"
 heroImage: "/images/work/scruggs-tire.png"
+liveUrl: "https://scruggstires.com"
 published: true
 ---
 

--- a/content/work/united-way.mdx
+++ b/content/work/united-way.mdx
@@ -11,6 +11,7 @@ services:
   - "WordPress Deployment"
   - "Ongoing Maintenance"
 heroImage: "/images/work/united-way.png"
+liveUrl: "https://uwayac.org"
 published: true
 ---
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -10,6 +10,23 @@ export const SITE_DESCRIPTION =
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/images/og/default.png`;
 
 /**
+ * Public business contact info (NAP). Single source of truth for the
+ * Contact page, Privacy policy, and JSON-LD structured data — keeping them
+ * consistent is what makes the NAP legible to Google Business Profile and AI
+ * agents. There is no public mailing address (the LLC's registered-agent
+ * address is not a place to send mail), so the location is city/state only.
+ *
+ * `CONTACT_EMAIL` is the general inbox (Contact page + Organization schema).
+ * `PRIVACY_EMAIL` is the GDPR/CCPA data-subject-request address on the
+ * Privacy policy.
+ */
+export const CONTACT_EMAIL = "info@shruggie.tech";
+export const PRIVACY_EMAIL = "admin@shruggie.tech";
+export const BUSINESS_LOCALITY = "Knoxville";
+export const BUSINESS_REGION = "TN";
+export const BUSINESS_LOCATION = "Knoxville, TN, USA";
+
+/**
  * Generate a dynamic OG image URL for a given page title.
  * Falls back to the static default if no title is provided.
  */

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,81 @@
+/**
+ * Plain-Markdown renderer for canonical research papers.
+ *
+ * These documents contain raw HTML (justified-paragraph <div>s, print rules)
+ * and literal angle-bracket tokens inside code (Vec<u8>, <float>), so they are
+ * rendered through a Markdown -> HTML pipeline rather than MDX. The pipeline:
+ *
+ *   remark-parse   -> Markdown AST
+ *   remark-gfm     -> tables, footnotes, strikethrough, autolinks
+ *   remark-rehype  -> HTML AST (allowDangerousHtml passes raw HTML through)
+ *   rehype-raw     -> re-parse the raw HTML into real nodes
+ *   rehype-slug    -> stable heading ids so anchors + the sidebar TOC work
+ *   (collect TOC)  -> gather <h2> ids/text for the sidebar, using the SAME
+ *                     ids rehype-slug produced (so links always resolve)
+ *   @shikijs/rehype-> syntax-highlight fenced code (github-dark, matches blog)
+ *   rehype-stringify
+ *
+ * Spec reference: §7.2 (content pipeline), §6.4 (Research)
+ */
+
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeRaw from "rehype-raw";
+import rehypeSlug from "rehype-slug";
+import rehypeShiki from "@shikijs/rehype";
+import rehypeStringify from "rehype-stringify";
+
+import type { TocItem } from "./utils";
+
+/* ── Minimal hast helpers (avoid extra deps) ────────────────────────────── */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type HastNode = any;
+
+function nodeText(node: HastNode): string {
+  if (node.type === "text") return node.value as string;
+  if (Array.isArray(node.children)) return node.children.map(nodeText).join("");
+  return "";
+}
+
+/** Rehype plugin: collect <h2> headings into `sink` (runs after rehype-slug). */
+function rehypeCollectToc(sink: TocItem[]) {
+  return (tree: HastNode) => {
+    const walk = (node: HastNode) => {
+      if (node.type === "element" && node.tagName === "h2") {
+        const id = node.properties?.id;
+        const text = nodeText(node).trim();
+        // Skip the paper's own in-body "Table of Contents" heading so the
+        // sidebar doesn't list a link to a table of contents.
+        if (id && text && !/^table of contents$/i.test(text)) {
+          sink.push({ id: String(id), text, level: 2 });
+        }
+      }
+      if (Array.isArray(node.children)) node.children.forEach(walk);
+    };
+    walk(tree);
+  };
+}
+
+/* ── Public API ─────────────────────────────────────────────────────────── */
+
+export async function renderMarkdown(
+  markdown: string,
+): Promise<{ html: string; toc: TocItem[] }> {
+  const toc: TocItem[] = [];
+
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSlug)
+    .use(rehypeCollectToc, toc)
+    .use(rehypeShiki, { theme: "github-dark" })
+    .use(rehypeStringify)
+    .process(markdown);
+
+  return { html: String(file), toc };
+}

--- a/lib/research.ts
+++ b/lib/research.ts
@@ -1,0 +1,82 @@
+/**
+ * Research content loading library.
+ *
+ * Reads .md files from content/research/, parses frontmatter with gray-matter,
+ * and exposes canonical publication metadata + raw markdown body. Unlike the
+ * blog (next-mdx-remote), research papers are rendered as plain Markdown via
+ * lib/markdown.ts, because the source documents contain raw HTML and literal
+ * angle-bracket tokens that an MDX/JSX parse would choke on.
+ *
+ * These are the canonical, on-site versions of work previously only published
+ * on GitHub gists; each paper's `gistUrl` is retained as a mirror.
+ *
+ * Spec reference: §6.4 (Research and Publications), §8.2 (JSON-LD)
+ */
+
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import readingTime from "reading-time";
+
+const RESEARCH_DIR = path.join(process.cwd(), "content", "research");
+
+export type ResearchSchemaType = "ScholarlyArticle" | "TechArticle";
+
+export interface ResearchMeta {
+  slug: string;
+  title: string;
+  subtitle?: string;
+  author: string;
+  date: string; // ISO 8601 datePublished
+  dateModified?: string; // ISO 8601 last revision
+  description: string;
+  schemaType: ResearchSchemaType;
+  gistUrl: string; // canonical mirror on GitHub
+  keywords: string[];
+  readingTime: string;
+}
+
+function toMeta(slug: string, data: Record<string, unknown>, content: string): ResearchMeta {
+  return {
+    slug,
+    title: String(data.title ?? ""),
+    subtitle: data.subtitle ? String(data.subtitle) : undefined,
+    author: String(data.author ?? "ShruggieTech"),
+    date: String(data.date ?? ""),
+    dateModified: data.dateModified ? String(data.dateModified) : undefined,
+    description: String(data.description ?? ""),
+    schemaType: (data.schemaType as ResearchSchemaType) ?? "TechArticle",
+    gistUrl: String(data.gistUrl ?? ""),
+    keywords: Array.isArray(data.keywords) ? (data.keywords as string[]) : [],
+    readingTime: readingTime(content).text,
+  };
+}
+
+export function getAllResearchMeta(): ResearchMeta[] {
+  if (!fs.existsSync(RESEARCH_DIR)) return [];
+
+  return fs
+    .readdirSync(RESEARCH_DIR)
+    .filter((f) => f.endsWith(".md"))
+    .map((filename) => {
+      const slug = filename.replace(/\.md$/, "");
+      const { data, content } = matter(
+        fs.readFileSync(path.join(RESEARCH_DIR, filename), "utf-8"),
+      );
+      return toMeta(slug, data, content);
+    })
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+export function getResearchBySlug(slug: string): {
+  meta: ResearchMeta;
+  content: string;
+} | null {
+  const filePath = path.join(RESEARCH_DIR, `${slug}.md`);
+  if (!fs.existsSync(filePath)) return null;
+
+  const { data, content } = matter(fs.readFileSync(filePath, "utf-8"));
+  return { meta: toMeta(slug, data, content), content };
+}
+
+export const RESEARCH_SLUGS = getAllResearchMeta().map((r) => r.slug);

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -8,7 +8,14 @@
  * Spec reference: §8.2 (JSON-LD Schema Markup)
  */
 
-import { SITE_URL, SITE_NAME } from "./constants";
+import {
+  SITE_URL,
+  SITE_NAME,
+  CONTACT_EMAIL,
+  BUSINESS_LOCALITY,
+  BUSINESS_REGION,
+} from "./constants";
+import { getAuthorByName } from "./team";
 
 /** Organization schema — injected on every page via root layout */
 export function generateOrganizationSchema() {
@@ -19,14 +26,17 @@ export function generateOrganizationSchema() {
     legalName: "Shruggie LLC",
     url: SITE_URL,
     logo: `${SITE_URL}/images/logo.svg`,
+    email: CONTACT_EMAIL,
     description:
       "A modern technical studio that builds digital systems, software, and AI-driven experiences.",
+    // City/state only — ShruggieTech has no public mailing location, so we do
+    // not assert a street address here (the LLC's registered-agent address is
+    // not a business location). Keeps structured data consistent with the
+    // visible NAP on /contact.
     address: {
       "@type": "PostalAddress",
-      streetAddress: "116 Agnes Rd, Ste 200",
-      addressLocality: "Knoxville",
-      addressRegion: "TN",
-      postalCode: "37919",
+      addressLocality: BUSINESS_LOCALITY,
+      addressRegion: BUSINESS_REGION,
       addressCountry: "US",
     },
     sameAs: ["https://github.com/shruggietech"],
@@ -59,6 +69,11 @@ export function generateBlogPostSchema(post: {
   slug: string;
   ogImage?: string;
 }) {
+  // Enrich the author with role, photo, bio, and social profiles (sameAs)
+  // when the byline maps to a known person — the signals Google's authorship
+  // guidance and AI citation heuristics reward.
+  const person = getAuthorByName(post.author);
+
   return {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -68,6 +83,12 @@ export function generateBlogPostSchema(post: {
       "@type": "Person",
       name: post.author,
       url: `${SITE_URL}/about`,
+      ...(person?.title && { jobTitle: person.title }),
+      ...(person?.image && { image: person.image }),
+      ...(person?.description && { description: person.description }),
+      ...(person?.socials.length && {
+        sameAs: person.socials.map((s) => s.href),
+      }),
     },
     publisher: {
       "@type": "Organization",
@@ -103,6 +124,88 @@ export function generateServiceSchema(service: {
   };
 }
 
+/** FAQPage schema — injected on service detail pages with real FAQs */
+export function generateFAQSchema(
+  faqs: { question: string; answer: string }[],
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  };
+}
+
+/** BreadcrumbList schema — injected on nested pages (e.g. service details) */
+export function generateBreadcrumbSchema(
+  crumbs: { name: string; url: string }[],
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map((crumb, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: crumb.name,
+      item: crumb.url,
+    })),
+  };
+}
+
+/**
+ * ScholarlyArticle / TechArticle schema for canonical research papers.
+ *
+ * `url` and `mainEntityOfPage` point at the on-site canonical version so the
+ * page — not the GitHub gist — is credited. The gist is declared as `sameAs`,
+ * marking it as a mirror of the same work.
+ */
+export function generateResearchSchema(paper: {
+  type: "ScholarlyArticle" | "TechArticle";
+  title: string;
+  author: string;
+  datePublished: string;
+  dateModified?: string;
+  description: string;
+  url: string; // canonical on-site URL
+  sameAs?: string[]; // mirrors (e.g. the GitHub gist)
+  keywords?: string[];
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": paper.type,
+    headline: paper.title,
+    name: paper.title,
+    author: {
+      "@type": "Person",
+      name: paper.author,
+      url: `${SITE_URL}/about`,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+      logo: `${SITE_URL}/images/logo.svg`,
+    },
+    datePublished: paper.datePublished,
+    ...(paper.dateModified && { dateModified: paper.dateModified }),
+    description: paper.description,
+    url: paper.url,
+    mainEntityOfPage: paper.url,
+    ...(paper.sameAs && paper.sameAs.length > 0 && { sameAs: paper.sameAs }),
+    ...(paper.keywords && paper.keywords.length > 0 && {
+      keywords: paper.keywords.join(", "),
+    }),
+    inLanguage: "en",
+    isAccessibleForFree: true,
+  };
+}
+
 /** TechArticle schema — injected on research/publication pages */
 export function generateTechArticleSchema(paper: {
   title: string;
@@ -135,7 +238,7 @@ export function generateSoftwareSchema(product: {
   description: string;
   url: string;
   codeRepository: string;
-  programmingLanguage: string;
+  programmingLanguage?: string;
   version?: string;
 }) {
   return {
@@ -145,7 +248,9 @@ export function generateSoftwareSchema(product: {
     description: product.description,
     url: product.url,
     codeRepository: product.codeRepository,
-    programmingLanguage: product.programmingLanguage,
+    ...(product.programmingLanguage && {
+      programmingLanguage: product.programmingLanguage,
+    }),
     ...(product.version && { version: product.version }),
     author: {
       "@type": "Organization",

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,0 +1,237 @@
+/**
+ * Service data: single source of truth for the Services hub (`/services`)
+ * and the four service detail pages (`/services/[slug]`).
+ *
+ * Each service renders as an anchored summary section on the hub AND as a
+ * standalone detail page with its own copy, capabilities, and FAQPage schema.
+ * This structure follows the site's own flagship guidance ("give your most
+ * important services their own pages instead of one crowded list, and put
+ * real FAQs on those pages, marked up with FAQ schema").
+ *
+ * FAQ DRAFTS, PENDING FOUNDER REVIEW. The `faqs` answers below are drafted
+ * from existing service copy, the ownership thesis, and the Discuss/Create/
+ * Deliver process. They are accurate to current positioning but should be
+ * reviewed and edited by the founders before being treated as authoritative
+ * marketing or legal claims. Wording is intentionally specific and checkable.
+ *
+ * Spec reference: §6.2 (Services), §8.2 (JSON-LD)
+ */
+
+export interface ServiceFaq {
+  question: string;
+  answer: string;
+}
+
+export interface ServiceDetail {
+  /** URL slug and anchor id, e.g. "strategy-brand" -> /services/strategy-brand */
+  slug: string;
+  /** Full pillar title */
+  title: string;
+  /** Short label for nav, cards, and breadcrumbs */
+  shortName: string;
+  /** One-line value statement */
+  lead: string;
+  /** Supporting paragraph */
+  body: string;
+  /** Concrete capabilities */
+  capabilities: string[];
+  /** 3-5 real client questions, see review note above */
+  faqs: ServiceFaq[];
+  /** Meta description (160 chars or fewer) for the detail page */
+  metaDescription: string;
+}
+
+export const SERVICES: ServiceDetail[] = [
+  {
+    slug: "strategy-brand",
+    title: "Digital Strategy & Brand",
+    shortName: "Strategy & Brand",
+    lead: "Your brand is the first thing people see and the last thing they remember. We make both count.",
+    body: "We build visual identity systems, brand standards kits, and content architecture from scratch, or refresh what already exists. Your brand should translate consistently across every platform and touchpoint, and we make sure it does.",
+    capabilities: [
+      "Logo design and visual identity systems",
+      "Color palette and typography systems",
+      "Brand standards kits",
+      "Website strategy and content architecture",
+      "Marketing collateral and print materials",
+    ],
+    metaDescription:
+      "Brand identity, standards kits, and content architecture that stay consistent across every platform. Built in Knoxville, TN, and yours to keep.",
+    faqs: [
+      {
+        question: "Do I own the logo and brand files you create?",
+        answer:
+          "Yes. Every asset we design is delivered to you and yours to keep: logo source files, color and type specifications, and the full brand standards kit. Ownership of what we build is a core policy, and every engagement is governed by a Master Services Agreement and Scope of Work.",
+      },
+      {
+        question: "Can you refresh our existing brand instead of starting over?",
+        answer:
+          "Yes. We build identity systems from scratch or refine what already exists. If your current brand mostly works, we audit it, keep what is strong, and fix the inconsistencies that show up across your website, print, and social profiles.",
+      },
+      {
+        question: "What is included in a brand standards kit?",
+        answer:
+          "A documented system others can follow without guessing: logo usage and spacing, the color palette with exact values, typography and hierarchy, and rules for how the brand appears across platforms. It is what keeps your brand consistent whether we apply it or your own team does.",
+      },
+      {
+        question: "We are a small business. Is a full identity system overkill?",
+        answer:
+          "Not necessarily. We scope brand work to what your situation needs. A local business might need a clean logo and a one-page standards sheet; a growing organization might need full content architecture. We recommend the smallest system that keeps you consistent, not the largest we can bill.",
+      },
+      {
+        question: "How does brand work connect to the rest of the site?",
+        answer:
+          "Content architecture is where strategy meets build. We plan how your pages are organized and what each one needs to say before development starts. That planning is also what makes your site legible to the search engines and AI systems that read it.",
+      },
+    ],
+  },
+  {
+    slug: "development",
+    title: "Development & Integration",
+    shortName: "Development",
+    lead: "We build, migrate, and integrate. From marketing sites to custom applications, we handle the full technical stack.",
+    body: "We work across whatever stack fits the project, not whatever stack we prefer. New build, migration, blockchain integration, or a compatibility layer over systems you can't replace, the approach is shaped by your situation, not ours.",
+    capabilities: [
+      "Custom website design and development",
+      "Modern web applications",
+      "CMS deployment, configuration, and migration",
+      "Blockchain architecture and smart contract development",
+      "Third-party integrations",
+      "DNS management and hosting configuration",
+      "Vendor displacement and replatforming",
+    ],
+    metaDescription:
+      "Custom websites, web apps, CMS migrations, and integrations, built on the stack that fits your project. You own the code, domain, and credentials.",
+    faqs: [
+      {
+        question: "What platforms and tech stacks do you work with?",
+        answer:
+          "We work across whatever stack fits the project, not whatever we prefer. That spans custom builds, modern web application frameworks, and mainstream CMS platforms like WordPress. If you are tied to a system you cannot replace, we can build a compatibility layer over it rather than forcing a rebuild.",
+      },
+      {
+        question: "Can you move our site off our current provider without downtime?",
+        answer:
+          "Yes. Replatforming and vendor displacement are core work. We migrate content, configure DNS and hosting, and stage the switch so it goes live cleanly. You end up holding your own domain, hosting credentials, and content when it is done.",
+      },
+      {
+        question: "Do we own the code and credentials when the project ends?",
+        answer:
+          "Yes. Your domain, hosting, and content stay yours, and there is no lock-in that holds your assets hostage. Engagements run under a formal Master Services Agreement and Scope of Work, so what you own is written down, not assumed.",
+      },
+      {
+        question: "Do you build custom web applications, or just websites?",
+        answer:
+          "Both. Alongside marketing sites we build custom web applications and third-party integrations, and we add AI and workflow automation where it saves real time: answering routine questions, moving data between the tools you already run, and cutting out repetitive manual steps. We scope to the problem and do not reach for complex technology a simpler build would solve.",
+      },
+      {
+        question: "Will the site be fast and accessible?",
+        answer:
+          "Page speed, mobile usability, and accessibility are treated as requirements, not extras. Ignored, they gate search visibility and shut out real users. We build them in from the start rather than bolting them on at the end.",
+      },
+    ],
+  },
+  {
+    slug: "marketing",
+    title: "Revenue Flows & Marketing Operations",
+    shortName: "Marketing Operations",
+    lead: "Visibility means nothing without conversion. We build the systems that turn attention into revenue.",
+    body: "Every business converts differently. A tour operator needs marketplace visibility. A local shop needs to own local search. An e-commerce brand needs a conversion funnel that doesn't leak. We tailor the strategy to how your customers actually find and buy from you.",
+    capabilities: [
+      "SEO strategy and execution",
+      "Answer Engine Optimization (AEO) with schema markup",
+      "Google Ads and Meta advertising",
+      "Social media strategy and content planning",
+      "Analytics implementation (GA4, GTM, Search Console)",
+      "Review generation and reputation management",
+      "Marketplace and platform listing optimization",
+    ],
+    metaDescription:
+      "SEO, Answer Engine Optimization, paid ads, and analytics, shaped around how your customers actually find and buy from you. Results you can measure.",
+    faqs: [
+      {
+        question: "What is Answer Engine Optimization (AEO), and do I need it?",
+        answer:
+          "AEO is optimizing your site so AI-driven search, such as Google's AI Mode, ChatGPT, and Perplexity, can read, summarize, and recommend you accurately. That means clear service pages, real FAQs, consistent business details, and structured data the machines can parse. If customers might ask an AI for a recommendation in your category, it matters.",
+      },
+      {
+        question: "How is AEO different from traditional SEO?",
+        answer:
+          "SEO aims to rank a page a person clicks; AEO aims to be the source an AI quotes when it answers on the person's behalf. They overlap, since both reward clear, specific, well-structured content, but AEO adds a machine-readable layer (JSON-LD schema, FAQ markup, consistent name, address, and phone) that classic SEO treated as optional.",
+      },
+      {
+        question: "Can you run our Google and Meta ads too?",
+        answer:
+          "Yes. We handle paid campaigns on Google Ads and Meta alongside the organic work, and we set up analytics first (GA4, Tag Manager, and Search Console) so you can see what each channel actually returns instead of guessing.",
+      },
+      {
+        question: "How do you measure whether marketing is working?",
+        answer:
+          "We instrument before we spend, so results are measured, not assumed. Then we track the metrics that map to revenue for your business, such as leads, calls, bookings, or sales, rather than vanity numbers that look good in a report and change nothing.",
+      },
+      {
+        question: "Every business converts differently. How do you tailor the strategy?",
+        answer:
+          "We start from how your customers actually find and buy from you. A tour operator needs marketplace visibility; a local shop needs to own local search; an e-commerce brand needs a funnel that does not leak. The strategy is shaped around your conversion path, not a fixed package.",
+      },
+    ],
+  },
+  {
+    slug: "ai-data",
+    title: "AI & Data Analysis",
+    shortName: "AI & Data",
+    lead: "AI is not magic. It is infrastructure. We help you build AI systems that solve real problems.",
+    body: "Most businesses don't need a custom model. They need AI wired into the systems they already use: answering customer questions, automating repetitive workflows, or surfacing the right data at the right time. We figure out where AI actually helps and build it into your operations.",
+    capabilities: [
+      "Conversational AI and chatbot development",
+      "RAG system design and implementation",
+      "Semantic and vector search integration",
+      "Workflow automation (email/SMS pipelines, process optimization)",
+      "AI adoption consulting",
+      "AI governance and responsible-use policy",
+      "AI literacy training for staff",
+      "Multi-agent coding workflow design",
+    ],
+    metaDescription:
+      "Chatbots, RAG systems, semantic search, and workflow automation wired into the tools you already use. We build the AI that solves a real problem and skip the rest.",
+    faqs: [
+      {
+        question: "Do we need a custom AI model?",
+        answer:
+          "Most businesses do not need a bespoke model. They need AI wired into the tools they already use: answering customer questions, automating repetitive workflows, or surfacing the right data at the right moment. We find where AI actually helps and build only that.",
+      },
+      {
+        question: "What can an AI chatbot actually do for our business?",
+        answer:
+          "A RAG (retrieval-augmented generation) chatbot is grounded in your own content, so it answers customer questions from your real documentation, policies, and FAQs instead of making things up. It handles routine questions at any hour and hands off the ones that need a human.",
+      },
+      {
+        question: "Is our data safe if we adopt AI tools?",
+        answer:
+          "We treat your data as yours, the same ownership principle that governs everything we build. We scope what a system can access, keep sensitive data where it belongs, and document it in the Scope of Work. We will also tell you plainly when AI is the wrong tool for the job.",
+      },
+      {
+        question: "What are RAG and semantic search, in plain terms?",
+        answer:
+          "Semantic (vector) search understands meaning rather than matching keywords, so a query finds the right answer even when the words do not match exactly. RAG, short for retrieval-augmented generation, puts that on top of an AI assistant so it answers from your actual content instead of guessing. The result is an assistant that is accurate about your business, not just fluent.",
+      },
+      {
+        question: "Can you help our team adopt AI in our own workflows?",
+        answer:
+          "Yes. Beyond building systems, we consult on AI adoption, including the multi-agent coding workflows we use ourselves, so your team learns where these tools help and where they add risk.",
+      },
+      {
+        question: "Can you help us set AI policy and train our team?",
+        answer:
+          "Yes. We help you put practical guardrails around AI: governance and acceptable-use policies your compliance and legal teams can actually apply, not boilerplate they have to rewrite, plus AI literacy training that shows your staff what these tools do well, where they fail, and how to use them without exposing the business. We meet your team at their current level and focus on the tools they will actually touch.",
+      },
+    ],
+  },
+];
+
+/** Look up a single service by slug. Returns undefined if not found. */
+export function getServiceBySlug(slug: string): ServiceDetail | undefined {
+  return SERVICES.find((service) => service.slug === slug);
+}
+
+/** All service slugs, used by generateStaticParams and the sitemap. */
+export const SERVICE_SLUGS = SERVICES.map((service) => service.slug);

--- a/lib/team.ts
+++ b/lib/team.ts
@@ -1,0 +1,68 @@
+/**
+ * Team / author registry — single source of truth for the people at
+ * ShruggieTech.
+ *
+ * Used by the About page team grid, blog post author boxes, and the
+ * BlogPosting JSON-LD author (name, jobTitle, image, sameAs). Keeping one
+ * registry means a bio or social link edited once stays consistent everywhere
+ * a person appears.
+ *
+ * Spec reference: §6.6 (About), §7.3 (Blog Post Template), §8.2 (JSON-LD)
+ */
+
+export interface SocialLink {
+  href: string;
+  label: string;
+  icon: string; // key into an icon map (e.g. "Linkedin", "Github")
+}
+
+export interface TeamMemberData {
+  name: string;
+  title: string;
+  description: string;
+  image: string;
+  socials: SocialLink[];
+}
+
+export const TEAM_MEMBERS: TeamMemberData[] = [
+  {
+    name: "William Thompson",
+    title: "Co-Founder & Chief Architect",
+    description:
+      "Software architect, systems designer, and the author of ShruggieTech's internal products and published research. Background in cryptography, electronic warfare, and high-performance computing. Writes specifications that AI agents can execute without asking questions.",
+    image: "https://cdn.shruggie.tech/avatars/william-thompson-toon.jpg",
+    socials: [
+      { href: "https://www.linkedin.com/in/willthompsonpro/", label: "LinkedIn", icon: "Linkedin" },
+      { href: "https://github.com/h8rt3rmin8r", label: "GitHub", icon: "Github" },
+    ],
+  },
+  {
+    name: "Natalie Thompson",
+    title: "Co-Founder & COO",
+    description:
+      "Self-taught full-stack developer, client relationship lead, and the person who makes everything actually happen. Pairs deep technical ability with the soft skills that keep complex projects moving forward. From branding to business development, she runs point on it all.",
+    image: "https://cdn.shruggie.tech/avatars/natalie-thompson-toon.jpg",
+    socials: [
+      { href: "https://www.linkedin.com/in/cryptasian/", label: "LinkedIn", icon: "Linkedin" },
+      { href: "https://www.facebook.com/cryptasian", label: "Facebook", icon: "Facebook" },
+      { href: "https://www.instagram.com/cryptasian/", label: "Instagram", icon: "Instagram" },
+      { href: "https://github.com/cryptasian", label: "GitHub", icon: "Github" },
+    ],
+  },
+  {
+    name: "Josiah Thompson",
+    title: "Founders Assistant",
+    description:
+      "Josiah contributes to ShruggieTech's production work, assisting with social media content creation, blog article drafting, and website maintenance. His role is designed to build real professional skills early, equipping him with the technical fluency and operational discipline for a career in technology.",
+    image: "https://cdn.shruggie.tech/avatars/josiah-thompson-toon.jpg",
+    socials: [
+      { href: "https://twitch.tv/notratmaster", label: "Twitch", icon: "Twitch" },
+      { href: "https://www.youtube.com/@notratmaster", label: "YouTube", icon: "Youtube" },
+    ],
+  },
+];
+
+/** Look up a team member by exact display name (e.g. a blog post's author). */
+export function getAuthorByName(name: string): TeamMemberData | undefined {
+  return TEAM_MEMBERS.find((member) => member.name === name);
+}

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -22,6 +22,9 @@ export interface CaseStudyMeta {
   summary: string;
   services: string[];
   heroImage: string; // Path to hero image (may not exist yet)
+  /** The client's live, shipped site. Renders a "Visit the live site" link
+   *  when present. Omit until the exact URL is confirmed — never guess it. */
+  liveUrl?: string;
   published: boolean;
 }
 
@@ -47,6 +50,7 @@ export function getAllCaseStudiesMeta(): CaseStudyMeta[] {
       summary: data.summary,
       services: data.services ?? [],
       heroImage: data.heroImage ?? "",
+      liveUrl: data.liveUrl || undefined,
       published: data.published !== false,
     } satisfies CaseStudyMeta;
   });
@@ -71,6 +75,7 @@ export function getCaseStudyBySlug(slug: string) {
       summary: data.summary,
       services: data.services ?? [],
       heroImage: data.heroImage ?? "",
+      liveUrl: data.liveUrl || undefined,
       published: data.published !== false,
     } satisfies CaseStudyMeta,
     content,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,10 @@
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.2",
         "reading-time": "^1.5.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-slug": "^6.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-gfm": "^4.0.1",
         "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
@@ -4521,6 +4525,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4720,6 +4730,77 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -4798,6 +4879,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-string": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
@@ -4818,6 +4918,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5958,6 +6075,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5966,6 +6093,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -5986,6 +6141,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6215,6 +6471,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-mdx-expression": {
@@ -7229,6 +7606,30 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7674,6 +8075,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-recma": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
@@ -7683,6 +8099,56 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7730,6 +8196,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8925,6 +9406,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-matter": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
@@ -8951,6 +9446,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.2",
     "reading-time": "^1.5.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-slug": "^6.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"


### PR DESCRIPTION
Broad content, SEO/AEO, and UX pass across the site.

## About / contact / NAP
- Dedupe the "Where We Come From" section into a single source of truth (was two drifted copies)
- Publish real NAP — `info@shruggie.tech`, Knoxville, TN — and fix the circular privacy-policy data-subject-request reference (now `admin@shruggie.tech`)
- Single-source the team registry (`lib/team.ts`) shared by the About page and blog authorship
- Contact page: reword the social CTA (no more phantom newsletter promise), icon-only socials, tighter spacing

## Services
- Four canonical detail pages (`/services/[slug]`) with FAQPage + Service + BreadcrumbList JSON-LD; hub links out; home cards link to detail pages
- FAQ copy drafted from existing positioning — **pending founder review**

## Research
- Host canonical papers on-site (`/research/[slug]`) with ScholarlyArticle / TechArticle schema; the GitHub gist is demoted to a `sameAs` mirror
- New plain-Markdown pipeline (remark-gfm / rehype-raw / rehype-slug) + sticky sidebar TOC

## Blog
- End-of-post CTA, author box with `sameAs`, named human byline on the AEO post
- Cite all six statistics in the AEO post; suppress single-page pagination

## Products
- Add **ShruggieGraph** (Coming Soon, alpha waitlist → graph.shruggie.tech); fix heading hierarchy under an H2 ("What We're Building"); guard SoftwareSourceCode schema for products without a public repo

## Work
- Confirmed live-site links on all three case studies

## Fixes
- Reset Lenis scroll on route change + route anchor clicks through Lenis (fixes jumpy navigation and the numeric-id anchor crash)
- Replace the legacy Twitter bird with the X logo

## Notes / follow-ups
- FAQ and service-detail copy is drafted for founder review before it's treated as authoritative
- Case studies still lack hard numbers, dates, and client quotes — needs real data from the team

🤖 Generated with [Claude Code](https://claude.com/claude-code)