### PR TITLE
fix: preserve Shiki code block classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Blog code blocks**: merge Shiki's generated class names with `CopyCodeBlock` container utilities so syntax highlighting keeps its theme while rounded corners, borders, padding, and overflow styling remain intact
 - **Lenis smooth scroll**: reset scroll position on client-side route changes and route in-page anchor clicks through Lenis, fixing jumpy navigation between pages and a `SyntaxError` crash on numeric-leading heading IDs (e.g. research paper tables of contents)
 - **Blog index spacing**: added symmetric bottom padding to the post grid (the removed "Page 1 of 1" element had been the only bottom spacer)
 - **Blog pagination**: hidden entirely on single-page lists instead of rendering a "Page 1 of 1" label

--- a/components/blog/CopyCodeBlock.tsx
+++ b/components/blog/CopyCodeBlock.tsx
@@ -3,8 +3,11 @@
 import { useRef, useState, type HTMLAttributes } from "react";
 import { Copy, Check } from "lucide-react";
 
+import { cn } from "@/lib/utils";
+
 export default function CopyCodeBlock({
   children,
+  className,
   ...props
 }: HTMLAttributes<HTMLPreElement>) {
   const ref = useRef<HTMLPreElement>(null);
@@ -23,8 +26,11 @@ export default function CopyCodeBlock({
     <div className="relative group">
       <pre
         ref={ref}
-        className="my-6 min-h-[3.5rem] overflow-x-auto rounded-lg border border-border p-4 pr-12 text-body-sm [&>code]:bg-transparent [&>code]:p-0"
         {...props}
+        className={cn(
+          "my-6 min-h-[3.5rem] overflow-x-auto rounded-lg border border-border p-4 pr-12 text-body-sm [&>code]:bg-transparent [&>code]:p-0",
+          className,
+        )}
       >
         {children}
       </pre>


### PR DESCRIPTION
## Summary

- extract Shiki's incoming className before spreading pre element props
- merge Shiki classes with CopyCodeBlock's container utilities using the existing cn helper
- preserve Shiki inline styles while retaining rounded corners, borders, padding, copy-button spacing, and horizontal overflow behavior
- document the fix in the changelog

## Verification

- npm run build
- npx tsc --noEmit
- npx eslint components/blog/CopyCodeBlock.tsx
- confirmed both generated code blocks contain shiki, github-dark, rounded-lg, border-border, p-4, and overflow-x-auto
- visually verified the corrected block in the local blog article

Fixes #4