### PR TITLE
content(products): remove ShruggieGraph from the public website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Product catalog**: removed the retired private-alpha product card, waitlist link, and site-wide footer entry
 - **Stale planning docs**: deleted `docs/ShruggieTech-Site-Updates-Plan-v2.md` (30-item UX backlog; audited against current code — 32/33 items already shipped, the one real gap filed as [#4](https://github.com/shruggietech/shruggie-web/issues/4)) and `.handoff/` (original greenfield sprint plan and its empty reports directory; audited and confirmed fully implemented) — both had drifted into describing work already completed rather than tracking anything outstanding
 
 ### Changed

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -17,7 +17,6 @@ import {
   Database,
   FileText,
   Cpu,
-  Network,
 } from "lucide-react";
 
 import { SITE_URL, getOgImageUrl } from "@/lib/constants";
@@ -80,7 +79,7 @@ interface Product {
   description: string;
   statusBadge: string;
   links: ProductLink[];
-  /** Optional: unreleased products (e.g. private alpha) have no public repo. */
+  /** Optional: products without a public repository omit code metadata. */
   programmingLanguage?: string;
   codeRepository?: string;
   version?: string;
@@ -88,17 +87,6 @@ interface Product {
 }
 
 const PRODUCTS: Product[] = [
-  {
-    id: "shruggiegraph",
-    name: "ShruggieGraph",
-    description:
-      "A permission-scoped, source-backed memory graph for AI. ShruggieGraph captures durable knowledge from your conversations and lets any AI assistant recall it across sessions and providers, with every fact traceable to the source it came from.",
-    statusBadge: "Coming Soon",
-    links: [
-      { label: "Join the alpha waitlist", href: "https://graph.shruggie.tech" },
-    ],
-    icon: Network,
-  },
   {
     id: "shruggie-indexer",
     name: "shruggie-indexer",
@@ -160,9 +148,7 @@ const PRODUCTS: Product[] = [
 export default function ProductsPage() {
   return (
     <>
-      {/* JSON-LD — only for products with a public code repository. Unreleased
-          products (e.g. ShruggieGraph in private alpha) get no SoftwareSourceCode
-          schema rather than a fabricated repo. */}
+      {/* JSON-LD is emitted only for products with a public code repository. */}
       {PRODUCTS.filter((product) => product.codeRepository).map((product) => (
         <JsonLd
           key={product.id}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -37,7 +37,6 @@ const PAGE_LINKS = [
 ] as const;
 
 const PRODUCT_LINKS = [
-  { href: "https://graph.shruggie.tech", label: "ShruggieGraph", external: true },
   { href: "/products#shruggie-indexer", label: "shruggie-indexer" },
   { href: "/products#metadexer", label: "metadexer" },
   { href: "/products#shruggie-feedtools", label: "shruggie-feedtools" },
@@ -101,28 +100,16 @@ export default function Footer() {
               Products
             </h3>
             <ul className="flex flex-col gap-3">
-              {PRODUCT_LINKS.map((link) => {
-                const linkClassName =
-                  "text-body-sm font-mono text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright";
-                return (
-                  <li key={link.href}>
-                    {"external" in link && link.external ? (
-                      <a
-                        href={link.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={linkClassName}
-                      >
-                        {link.label}
-                      </a>
-                    ) : (
-                      <Link href={link.href} className={linkClassName}>
-                        {link.label}
-                      </Link>
-                    )}
-                  </li>
-                );
-              })}
+              {PRODUCT_LINKS.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="text-body-sm font-mono text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </div>
 


### PR DESCRIPTION
## Summary

- remove the retired private-alpha product card and waitlist link from `/products`
- remove its site-wide footer entry and simplify the footer product links to their remaining internal-link behavior
- add a neutral Unreleased changelog entry while preserving historical release notes

## GitHub planning

- closes #32
- closes #1 as not planned because it requested additional content for the retired product
- updates #17, #19, #20, #21, and #30 so no other open issue requests or assumes future website content for it
- tracks the unrelated repository-wide ESLint baseline separately in #33

## Validation

- `npm run build` passes
- `npx tsc --noEmit` passes
- `npx eslint app/products/page.tsx components/layout/Footer.tsx` passes
- built server output contains no removed product name or waitlist-domain references
- `git diff --check` passes
- three independent correctness, frontend/accessibility, and security/scope reviews reported no actionable findings

`npm run lint` was also run. It reports seven pre-existing React-rule errors and two warnings in untouched files; #33 records that baseline. The files changed in this pull request pass ESLint and add no lint findings.

Closes #32