### PR TITLE
fix(build): restore ESLint baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **ESLint baseline**: replaced render-time ref mutation and synchronous effect state updates with behavior-preserving derived state and browser subscriptions across navigation, responsive hooks, cookie consent, blog table-of-contents tracking, and product/homepage animation components; documented the required native image exception for edge-rendered Open Graph cards
 - **Development pillar**: added blockchain integration to the pillar description and "Blockchain architecture and smart contract development" to the capabilities list
 - **Service anchor map**: added `Blockchain`, `Smart Contracts`, and `Blockchain Consulting` entries linking to the Development & Integration pillar
 - **About "Where We Come From"**: extracted the duplicated heading and origin paragraph — which had drifted between the mobile and desktop layouts — into single `ORIGIN_HEADING`/`ORIGIN_STORY` constants

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -253,8 +253,11 @@ export async function GET(request: NextRequest) {
         >
           {/* Logo: large for mobile visibility */}
           {logoBase64 ? (
+            // next/image cannot render inside a next/og ImageResponse.
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={logoBase64}
+              alt="ShruggieTech"
               height={56}
               style={{
                 objectFit: "contain",

--- a/components/blog/TableOfContents.tsx
+++ b/components/blog/TableOfContents.tsx
@@ -9,7 +9,7 @@
 
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import type { TocItem } from "@/lib/utils";
 
@@ -33,11 +33,9 @@ export default function TableOfContents({
   collapsible = false,
 }: TableOfContentsProps) {
   const [activeId, setActiveId] = useState<string>("");
-  const headingsRef = useRef(headings);
-  headingsRef.current = headings;
 
   useEffect(() => {
-    const elements = headingsRef.current
+    const elements = headings
       .map(({ id }) => document.getElementById(id))
       .filter(Boolean) as HTMLElement[];
 
@@ -59,7 +57,7 @@ export default function TableOfContents({
 
     // When the user scrolls to the bottom of the page, activate the last
     // heading even if it never crossed the observer threshold (short section).
-    const lastId = headingsRef.current[headingsRef.current.length - 1]?.id;
+    const lastId = headings[headings.length - 1]?.id;
     const onScroll = () => {
       const atBottom =
         window.innerHeight + window.scrollY >=

--- a/components/home/HeroBackground.tsx
+++ b/components/home/HeroBackground.tsx
@@ -247,6 +247,7 @@ interface ShruggieState {
 export default function HeroBackground() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>(0);
+  const drawRef = useRef<() => void>(() => {});
   const mouseRef = useRef<{ x: number; y: number } | null>(null);
   const driftRef = useRef({ x: 0, y: 0, angle: 0 });
   const reducedMotionRef = useRef(false);
@@ -549,9 +550,13 @@ export default function HeroBackground() {
     ctx.restore();
 
     if (!reducedMotionRef.current) {
-      animationRef.current = requestAnimationFrame(draw);
+      animationRef.current = requestAnimationFrame(() => drawRef.current());
     }
   }, []);
+
+  useEffect(() => {
+    drawRef.current = draw;
+  }, [draw]);
 
   useEffect(() => {
     const canvas = canvasRef.current;

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -10,7 +10,12 @@
 
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -30,24 +35,49 @@ const NAV_LINKS = [
   { href: "/blog", label: "Blog" },
 ] as const;
 
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribeToReducedMotion(onStoreChange: () => void) {
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getReducedMotionSnapshot() {
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function subscribeToTheme(onStoreChange: () => void) {
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+  return () => observer.disconnect();
+}
+
+function getThemeSnapshot() {
+  return document.documentElement.classList.contains("dark");
+}
+
 export default function Header() {
   const pathname = usePathname();
   const forceDark = isDarkModeForced(pathname);
   const [scrollY, setScrollY] = useState(0);
-  const [isDark, setIsDark] = useState(true);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    () => false,
+  );
+  const isDark = useSyncExternalStore(
+    subscribeToTheme,
+    getThemeSnapshot,
+    () => true,
+  );
 
   // Track scroll position for progressive opacity
   useEffect(() => {
-    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setPrefersReducedMotion(motionQuery.matches);
-
-    const handleMotionChange = (e: MediaQueryListEvent) => {
-      setPrefersReducedMotion(e.matches);
-    };
-    motionQuery.addEventListener("change", handleMotionChange);
-
     const handleScroll = () => {
       setScrollY(window.scrollY);
     };
@@ -57,30 +87,12 @@ export default function Header() {
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
-      motionQuery.removeEventListener("change", handleMotionChange);
     };
-  }, []);
-
-  // Initialize theme state from DOM and watch for external class changes
-  useEffect(() => {
-    setIsDark(document.documentElement.classList.contains("dark"));
-
-    // MutationObserver keeps isDark in sync when other code (e.g. ThemeEnforcer)
-    // modifies the class list without going through toggleTheme.
-    const observer = new MutationObserver(() => {
-      setIsDark(document.documentElement.classList.contains("dark"));
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-    return () => observer.disconnect();
   }, []);
 
   // Theme toggle: set cookie + toggle class (§2.6)
   const toggleTheme = useCallback(() => {
     const newIsDark = !isDark;
-    setIsDark(newIsDark);
     document.documentElement.classList.toggle("dark", newIsDark);
 
     const theme = newIsDark ? "dark" : "light";

--- a/components/products/SpecToShipIllustration.tsx
+++ b/components/products/SpecToShipIllustration.tsx
@@ -12,23 +12,18 @@
  * and gated behind the `.is-animating` CSS class.
  */
 
-import { useRef, useEffect, useState } from "react";
+import { useRef } from "react";
 import { useInView } from "framer-motion";
 import styles from "./SpecToShipIllustration.module.css";
 
 export default function SpecToShipIllustration() {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const isInView = useInView(wrapperRef, { once: true, margin: "-80px" });
-  const [animating, setAnimating] = useState(false);
-
-  useEffect(() => {
-    if (isInView) setAnimating(true);
-  }, [isInView]);
 
   return (
     <div
       ref={wrapperRef}
-      className={`w-full max-w-[360px] mx-auto h-[280px] md:h-auto md:mx-0${animating ? " is-animating" : ""}`}
+      className={`w-full max-w-[360px] mx-auto h-[280px] md:h-auto md:mx-0${isInView ? " is-animating" : ""}`}
     >
       <svg
         viewBox="0 0 480 560"

--- a/components/shared/CookieConsent.tsx
+++ b/components/shared/CookieConsent.tsx
@@ -12,10 +12,12 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import Link from "next/link";
 
 import Button from "@/components/ui/Button";
+
+const CONSENT_CHANGE_EVENT = "shruggie:consent-change";
 
 function getConsentCookie(): string | null {
   if (typeof document === "undefined") return null;
@@ -27,28 +29,31 @@ function setConsentCookie(value: "granted" | "denied") {
   const expires = new Date();
   expires.setFullYear(expires.getFullYear() + 1);
   document.cookie = `consent=${value}; expires=${expires.toUTCString()}; path=/; SameSite=Lax`;
+  window.dispatchEvent(new Event(CONSENT_CHANGE_EVENT));
+}
+
+function subscribeToConsent(onStoreChange: () => void) {
+  window.addEventListener(CONSENT_CHANGE_EVENT, onStoreChange);
+  return () => window.removeEventListener(CONSENT_CHANGE_EVENT, onStoreChange);
 }
 
 export default function CookieConsent() {
-  const [visible, setVisible] = useState(false);
+  const consent = useSyncExternalStore(
+    subscribeToConsent,
+    getConsentCookie,
+    () => undefined,
+  );
 
-  useEffect(() => {
-    // Only show if no consent cookie exists
-    if (!getConsentCookie()) {
-      setVisible(true);
-    }
-  }, []);
-
-  if (!visible) return null;
+  // The server snapshot stays hidden to avoid a hydration mismatch. On the
+  // client, a missing cookie is represented by null and shows the banner.
+  if (consent !== null) return null;
 
   const handleAccept = () => {
     setConsentCookie("granted");
-    setVisible(false);
   };
 
   const handleDecline = () => {
     setConsentCookie("denied");
-    setVisible(false);
   };
 
   return (

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 const MOBILE_QUERY = "(max-width: 767px)";
 
@@ -9,16 +9,16 @@ const MOBILE_QUERY = "(max-width: 767px)";
  * Uses matchMedia for efficient detection. Returns false during SSR.
  */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const mql = window.matchMedia(MOBILE_QUERY);
-    setIsMobile(mql.matches);
-
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mql.addEventListener("change", handler);
-    return () => mql.removeEventListener("change", handler);
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    const mediaQuery = window.matchMedia(MOBILE_QUERY);
+    mediaQuery.addEventListener("change", onStoreChange);
+    return () => mediaQuery.removeEventListener("change", onStoreChange);
   }, []);
 
-  return isMobile;
+  const getSnapshot = useCallback(
+    () => window.matchMedia(MOBILE_QUERY).matches,
+    [],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }


### PR DESCRIPTION
## Summary

- replace render-time ref mutation and synchronous effect state updates with derived state and browser subscriptions
- preserve canvas animation, responsive navigation, theme tracking, cookie consent, TOC activation, and product illustration behavior
- add alt text plus a narrow documented native-image exception for the edge-rendered Open Graph card
- record the maintenance change in the Unreleased changelog

## Verification

- 
pm run lint
- 
px tsc --noEmit
- 
pm run build
- desktop theme toggle and restoration
- article table-of-contents activation
- 390px mobile navigation open/close behavior
- browser console: no warnings or errors

Fixes #33