### PR TITLE
fix(accessibility): correct light-theme green contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Light-theme green contrast**: added an accessible `#037B40` foreground/focus token for green text, links, and focus indicators on `#F8F8F6`, while preserving bright `#2BCC73` as the dark-surface identity accent; added automated contrast and semantic-token regression coverage
 - **Specification framework version**: removed the stale Next.js 15 reference from §1.1 and made the framework entry version-agnostic so `package.json` remains the canonical installed version
 - **Blog code blocks**: merge Shiki's generated class names with `CopyCodeBlock` container utilities so syntax highlighting keeps its theme while rounded corners, borders, padding, and overflow styling remain intact
 - **Lenis smooth scroll**: reset scroll position on client-side route changes and route in-page anchor clicks through Lenis, fixing jumpy navigation between pages and a `SyntaxError` crash on numeric-leading heading IDs (e.g. research paper tables of contents)

--- a/ShruggieTech_Website_Specification.md
+++ b/ShruggieTech_Website_Specification.md
@@ -407,7 +407,7 @@ The palette is drawn directly from the brand identity established in KB §10.1. 
 | Token | Hex | Usage |
 |-------|-----|-------|
 | `--color-black` | `#000000` | Primary background (dark mode), text (light mode) |
-| `--color-green-bright` | `#2BCC73` | Primary accent, interactive elements, links, highlights |
+| `--color-green-bright` | `#2BCC73` | Bright identity accent on dark surfaces, decorative elements, highlights |
 | `--color-green-deep` | `#00AB21` | Logo mark, secondary accent, hover states |
 | `--color-orange` | `#FF5300` | CTA emphasis, alerts, energy accents |
 | `--color-gray-light` | `#D1D3D4` | Borders, secondary text, dividers |
@@ -424,6 +424,7 @@ The palette is drawn directly from the brand identity established in KB §10.1. 
 | `--color-gray-400` | `#9A9A9A` | Muted text (light mode) |
 | `--color-gray-200` | `#E5E5E5` | Borders (light mode) |
 | `--color-gray-100` | `#F5F5F5` | Surface (light mode cards) |
+| `--color-green-foreground` | `#037B40` | Accessible green text, links, and focus indicators on light surfaces |
 | `--color-green-bright-10` | `rgba(43, 204, 115, 0.10)` | Subtle accent backgrounds |
 | `--color-green-bright-20` | `rgba(43, 204, 115, 0.20)` | Badge backgrounds, active states |
 | `--color-orange-10` | `rgba(255, 83, 0, 0.10)` | Subtle CTA highlight backgrounds |
@@ -441,6 +442,7 @@ The palette is drawn directly from the brand identity established in KB §10.1. 
     --color-black: 0 0 0;
     --color-white: 255 255 255;
     --color-green-bright: 43 204 115;
+    --color-green-foreground: 3 123 64;
     --color-green-deep: 0 171 33;
     --color-orange: 255 83 0;
     --color-gray-light: 209 211 212;
@@ -453,8 +455,9 @@ The palette is drawn directly from the brand identity established in KB §10.1. 
     --color-text-secondary: 107 107 107;
     --color-text-muted: 154 154 154;
     --color-border: 229 229 229;
-    --color-accent: var(--color-green-bright);
-    --color-accent-hover: var(--color-green-deep);
+    --color-accent: var(--color-green-foreground);
+    --color-accent-hover: 2 94 49;
+    --color-focus: var(--color-green-foreground);
     --color-cta: var(--color-orange);
   }
 
@@ -468,6 +471,7 @@ The palette is drawn directly from the brand identity established in KB §10.1. 
     --color-border: 38 38 38;
     --color-accent: var(--color-green-bright);
     --color-accent-hover: var(--color-green-deep);
+    --color-focus: var(--color-green-bright);
     --color-cta: var(--color-orange);
   }
 }
@@ -649,7 +653,7 @@ For multi-column layouts (services grid, team cards, product cards), use CSS Gri
 
 <div style="text-align:justify">
 
-Two visual variants (primary and secondary) and two sizes (default and small). Primary uses the brand orange for maximum CTA energy. Secondary uses a bordered, transparent treatment. Both have subtle hover transitions. All buttons must be keyboard-focusable with a visible focus ring that uses the bright green accent.
+Two visual variants (primary and secondary) and two sizes (default and small). Primary uses the brand orange for maximum CTA energy. Secondary uses a bordered, transparent treatment. Both have subtle hover transitions. All buttons must be keyboard-focusable with a visible focus ring that uses the theme-aware focus token: accessible foreground green on light surfaces and bright green on dark surfaces.
 
 </div>
 
@@ -954,9 +958,9 @@ Section 508 of the Rehabilitation Act requires that electronic and information t
 <a name="32-implementation-patterns" id="32-implementation-patterns"></a>
 ### 3.2. Implementation Patterns
 
-**Color contrast:** All text-on-background combinations must meet WCAG AA contrast ratios (4.5:1 for normal text, 3:1 for large text). The brand green `#2BCC73` on black `#000000` achieves a contrast ratio of approximately 8.9:1 (passes). The brand green on white `#FFFFFF` achieves approximately 2.4:1 (fails for body text). Therefore, in light mode, green accent text must be darkened to `#00AB21` (deep green, approximately 3.6:1) or used only for large text, icons, and decorative elements. Body text in light mode uses `#0A0A0A` on `#FFFFFF` (passes at approximately 19.5:1).
+**Color contrast:** All text-on-background combinations must meet WCAG AA contrast ratios (4.5:1 for normal text, 3:1 for large text). The bright brand green `#2BCC73` remains the identity accent on dark surfaces, where it passes. It measures approximately 1.98:1 on the light reading surface `#F8F8F6`, so it must not be used for normal-size foreground text or focus indicators there. Light-mode green foreground roles use `#037B40`, which measures approximately 5.05:1 on `#F8F8F6`. Body text in light mode uses `#0A0A0A` on the light surface and remains comfortably above AA.
 
-**Keyboard navigation:** Every interactive element must be reachable via Tab key. Focus order must follow visual reading order. Focus indicators use a 2px solid outline in `#2BCC73` with a 2px offset, providing clear visibility on both dark and light backgrounds. The site must include a "Skip to main content" link as the first focusable element on every page.
+**Keyboard navigation:** Every interactive element must be reachable via Tab key. Focus order must follow visual reading order. Focus indicators use a 2px solid outline with a 2px offset. The semantic focus token resolves to `#037B40` on light surfaces and `#2BCC73` on dark surfaces. The site must include a "Skip to main content" link as the first focusable element on every page.
 
 **Skip link implementation (`components/ui/SkipLink.tsx`):**
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -90,7 +90,7 @@ export default function ContactPage() {
             <div className="flex flex-col items-center justify-center gap-4 text-center sm:flex-row sm:gap-8">
               <a
                 href={`mailto:${CONTACT_EMAIL}`}
-                className="flex items-center gap-2 text-body text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                className="flex items-center gap-2 text-body text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
               >
                 <Mail size={20} aria-hidden="true" />
                 <span className="font-medium">{CONTACT_EMAIL}</span>
@@ -114,7 +114,7 @@ export default function ContactPage() {
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label={link.label}
-                    className="flex items-center justify-center rounded-lg border border-border bg-bg-secondary p-3 text-text-secondary transition-colors duration-200 hover:border-brand-green-bright hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                    className="flex items-center justify-center rounded-lg border border-border bg-bg-secondary p-3 text-text-secondary transition-colors duration-200 hover:border-accent hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
                   >
                     <link.Icon size={20} aria-hidden="true" />
                   </a>

--- a/app/services/ServicePillarSection.tsx
+++ b/app/services/ServicePillarSection.tsx
@@ -144,7 +144,7 @@ export default function ServicePillarSection({
               {detailHref && (
                 <Link
                   href={detailHref}
-                  className="group mt-8 inline-flex items-center gap-2 font-display text-body-md font-medium text-accent hover:text-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                  className="group mt-8 inline-flex items-center gap-2 font-display text-body-md font-medium text-accent hover:text-accent-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
                 >
                   Explore {title}
                   <ArrowRight

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -132,7 +132,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
             href={meta.liveUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="group mt-6 inline-flex items-center gap-2 rounded-lg border border-accent/30 px-4 py-2 font-display text-body-sm font-medium text-accent transition-colors hover:border-accent hover:bg-accent/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+            className="group mt-6 inline-flex items-center gap-2 rounded-lg border border-accent/30 px-4 py-2 font-display text-body-sm font-medium text-accent transition-colors hover:border-accent hover:bg-accent/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
           >
             Visit the live site
             <ExternalLink

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -108,7 +108,7 @@ export default function ContactForm() {
           autoComplete="name"
           aria-invalid={errors.name ? "true" : undefined}
           aria-describedby={errors.name ? "contact-name-error" : undefined}
-          className="w-full rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-brand-green-bright/40"
+          className="w-full rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-focus/40"
           placeholder="Your name"
           {...register("name")}
         />
@@ -137,7 +137,7 @@ export default function ContactForm() {
           autoComplete="email"
           aria-invalid={errors.email ? "true" : undefined}
           aria-describedby={errors.email ? "contact-email-error" : undefined}
-          className="w-full rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-brand-green-bright/40"
+          className="w-full rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-focus/40"
           placeholder="you@company.com"
           {...register("email")}
         />
@@ -164,7 +164,7 @@ export default function ContactForm() {
           id="contact-company"
           type="text"
           autoComplete="organization"
-          className="w-full rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-brand-green-bright/40"
+          className="w-full rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-focus/40"
           placeholder="Your company (optional)"
           {...register("company")}
         />
@@ -185,7 +185,7 @@ export default function ContactForm() {
           aria-describedby={
             errors.message ? "contact-message-error" : undefined
           }
-          className="w-full resize-y rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-brand-green-bright/40"
+          className="w-full resize-y rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 text-body-md text-text-primary placeholder:text-text-muted transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-focus/40"
           placeholder="Tell us about your project or question"
           {...register("message")}
         />
@@ -211,7 +211,7 @@ export default function ContactForm() {
         <div className="relative">
           <select
             id="contact-referral"
-            className="w-full appearance-none rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 pr-10 text-body-md text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-brand-green-bright/40"
+            className="w-full appearance-none rounded-lg border border-border/50 bg-bg-elevated/50 backdrop-blur-sm px-4 py-3 pr-10 text-body-md text-text-primary transition-colors focus:border-accent focus:outline-none focus:ring-2 focus:ring-focus/40"
             {...register("referral")}
           >
             <option value="">Select an option (optional)</option>

--- a/components/blog/Pagination.tsx
+++ b/components/blog/Pagination.tsx
@@ -39,14 +39,14 @@ export default function Pagination({
           {currentPage > 1 ? (
             <Link
               href={getPageHref(currentPage - 1)}
-              className="rounded-lg border border-border px-3 py-2 text-body-sm text-text-secondary transition-colors hover:border-accent hover:text-accent"
+              className="border-border text-body-sm text-text-secondary hover:border-accent hover:text-accent rounded-lg border px-3 py-2 transition-colors"
               aria-label="Previous page"
             >
               &larr; Prev
             </Link>
           ) : (
             <span
-              className="cursor-not-allowed rounded-lg border border-border/50 px-3 py-2 text-body-sm text-text-muted"
+              className="border-border/50 text-body-sm text-text-muted cursor-not-allowed rounded-lg border px-3 py-2"
               aria-disabled="true"
             >
               &larr; Prev
@@ -59,7 +59,7 @@ export default function Pagination({
           <li key={page}>
             {page === currentPage ? (
               <span
-                className="rounded-lg bg-accent px-3 py-2 text-body-sm font-medium text-black"
+                className="bg-accent text-body-sm rounded-lg px-3 py-2 font-medium text-white dark:text-black"
                 aria-current="page"
               >
                 {page}
@@ -68,8 +68,8 @@ export default function Pagination({
               <Link
                 href={getPageHref(page)}
                 className={cn(
-                  "rounded-lg border border-border px-3 py-2 text-body-sm text-text-secondary",
-                  "transition-colors hover:border-accent hover:text-accent",
+                  "border-border text-body-sm text-text-secondary rounded-lg border px-3 py-2",
+                  "hover:border-accent hover:text-accent transition-colors",
                 )}
               >
                 {page}
@@ -83,14 +83,14 @@ export default function Pagination({
           {currentPage < totalPages ? (
             <Link
               href={getPageHref(currentPage + 1)}
-              className="rounded-lg border border-border px-3 py-2 text-body-sm text-text-secondary transition-colors hover:border-accent hover:text-accent"
+              className="border-border text-body-sm text-text-secondary hover:border-accent hover:text-accent rounded-lg border px-3 py-2 transition-colors"
               aria-label="Next page"
             >
               Next &rarr;
             </Link>
           ) : (
             <span
-              className="cursor-not-allowed rounded-lg border border-border/50 px-3 py-2 text-body-sm text-text-muted"
+              className="border-border/50 text-body-sm text-text-muted cursor-not-allowed rounded-lg border px-3 py-2"
               aria-disabled="true"
             >
               Next &rarr;

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -53,7 +53,7 @@ export default function Footer() {
           <div>
             <Link
               href="/"
-              className="inline-flex items-center gap-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+              className="inline-flex items-center gap-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
             >
               <Image
                 src="/images/logo-darkbg.png"
@@ -85,7 +85,7 @@ export default function Footer() {
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-body-sm text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                    className="text-body-sm text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
                   >
                     {link.label}
                   </Link>
@@ -104,7 +104,7 @@ export default function Footer() {
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="text-body-sm font-mono text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                    className="text-body-sm font-mono text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
                   >
                     {link.label}
                   </Link>
@@ -126,7 +126,7 @@ export default function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={link.label}
-                  className="text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+                  className="text-text-secondary transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
                 >
                   <link.Icon size={20} aria-hidden="true" />
                 </a>
@@ -165,7 +165,7 @@ export default function Footer() {
           </p>
           <Link
             href="/privacy"
-            className="text-body-xs text-text-muted transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright"
+            className="text-body-xs text-text-muted transition-colors duration-200 hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
           >
             Privacy Policy
           </Link>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -128,7 +128,7 @@ export default function Header() {
             href="/"
             className={cn(
               "flex items-center gap-2",
-              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+              "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
             )}
           >
             <Image
@@ -161,7 +161,7 @@ export default function Header() {
                 className={cn(
                   "group relative px-3 py-2 font-body text-body-sm font-medium uppercase tracking-wide text-text-secondary",
                   "transition-colors duration-200 hover:text-text-primary",
-                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
                 )}
               >
                 {link.label}
@@ -188,7 +188,7 @@ export default function Header() {
                 className={cn(
                   "rounded-lg p-2 text-text-secondary transition-colors",
                   "hover:text-text-primary",
-                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
                 )}
               >
                 {isDark ? (
@@ -215,7 +215,7 @@ export default function Header() {
               className={cn(
                 "rounded-lg p-2 text-text-secondary transition-colors nav:hidden",
                 "hover:text-text-primary",
-                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+                "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
               )}
             >
               <Menu size={24} aria-hidden="true" />

--- a/components/layout/MobileNav.tsx
+++ b/components/layout/MobileNav.tsx
@@ -118,7 +118,7 @@ export default function MobileNav({ isOpen, onClose }: MobileNavProps) {
           className={cn(
             "rounded-lg p-2 text-text-primary transition-colors",
             "hover:text-accent",
-            "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+            "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
           )}
         >
           <X size={28} aria-hidden="true" />
@@ -137,7 +137,7 @@ export default function MobileNav({ isOpen, onClose }: MobileNavProps) {
                   "block font-display text-[28px] font-medium text-text-primary",
                   "transition-colors duration-200",
                   "hover:text-accent",
-                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+                  "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
                 )}
               >
                 {link.label}

--- a/components/shared/BackToTop.tsx
+++ b/components/shared/BackToTop.tsx
@@ -28,7 +28,7 @@ export default function BackToTop() {
         "rounded-full bg-cta text-white shadow-lg",
         "transition-all duration-300 ease-out",
         "hover:brightness-110 active:brightness-95",
-        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
         visible
           ? "translate-y-0 opacity-100"
           : "pointer-events-none translate-y-4 opacity-0",

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -4,7 +4,7 @@
  * Two variants (primary, secondary) and two sizes (default, sm).
  * Primary uses bg-cta with brightness hover effects.
  * Secondary uses bordered transparent treatment.
- * Both require visible focus rings using brand green (#2BCC73).
+ * Both require visible focus rings using the theme-aware focus token.
  *
  * Spec reference: §2.4 (Component Primitives), §3.2 (Accessibility)
  */
@@ -30,7 +30,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           // Base
           "inline-flex items-center justify-center font-display font-medium",
           "rounded-lg transition-all duration-200 ease-out",
-          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-green-bright",
+          "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus",
           // Size
           size === "default" && "px-6 py-3 text-body-md",
           size === "sm" && "px-4 py-2 text-body-sm",

--- a/components/ui/SectionProgress.tsx
+++ b/components/ui/SectionProgress.tsx
@@ -43,7 +43,7 @@ export function SectionProgress({ total, current, className, labels, onSelect }:
               aria-label={labels?.[i] ?? `Section ${i + 1}`}
               onClick={() => onSelect?.(i)}
               className={cn(
-                "block cursor-pointer rounded-full border transition-all duration-300 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-green-bright focus-visible:ring-offset-2 focus-visible:ring-offset-black",
+                "block cursor-pointer rounded-full border transition-all duration-300 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-black",
                 i === current
                   ? "size-2.5 border-brand-green-bright bg-brand-green-bright"
                   : "size-2 border-white/20 bg-transparent hover:border-white/40",

--- a/components/ui/SkipLink.tsx
+++ b/components/ui/SkipLink.tsx
@@ -14,10 +14,10 @@ export default function SkipLink() {
     <a
       href="#main-content"
       className={cn(
-        "fixed left-4 top-4 z-[9999]",
-        "rounded-lg bg-accent px-4 py-2 font-display text-body-sm font-medium text-black",
-        "opacity-0 -translate-y-full transition-all duration-200",
-        "focus-visible:opacity-100 focus-visible:translate-y-0",
+        "fixed top-4 left-4 z-[9999]",
+        "bg-accent font-display text-body-sm rounded-lg px-4 py-2 font-medium text-white dark:text-black",
+        "-translate-y-full opacity-0 transition-all duration-200",
+        "focus-visible:translate-y-0 focus-visible:opacity-100",
         "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
       )}
     >

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "npm run test:contrast",
+    "test:contrast": "node --test tests/color-contrast.test.mjs"
   },
   "dependencies": {
     "@formspree/react": "^3.0.0",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,6 +28,7 @@
     --brand-black: #000000;
     --brand-white: #FFFFFF;
     --brand-green-bright: #2BCC73;
+    --brand-green-foreground: #037B40;
     --brand-green-deep: #00AB21;
     --brand-orange: #FF5300;
     --brand-gray-light: #D1D3D4;
@@ -40,8 +41,9 @@
     --text-secondary: #6B6B6B;
     --text-muted: #9A9A9A;
     --border-color: #E5E5E5;
-    --accent-color: #2BCC73;
-    --accent-hover-color: #00AB21;
+    --accent-color: var(--brand-green-foreground);
+    --accent-hover-color: #025E31;
+    --focus-color: var(--brand-green-foreground);
     --cta-color: #C24000; /* Darkened from #FF5300 for WCAG AA (4.6:1 vs white) */
 
     /* Layout constants (spec §2.3) — mobile defaults */
@@ -61,8 +63,9 @@
     --text-secondary: #D1D3D4;
     --text-muted: #6B6B6B;
     --border-color: #262626;
-    --accent-color: #2BCC73;
-    --accent-hover-color: #00AB21;
+    --accent-color: var(--brand-green-bright);
+    --accent-hover-color: var(--brand-green-deep);
+    --focus-color: var(--brand-green-bright);
     --cta-color: #C24000; /* Darkened from #FF5300 for WCAG AA (4.6:1 vs white) */
 
     /* Section surface colors (redesign §1.1–1.2) */
@@ -142,6 +145,7 @@
   --color-border: var(--border-color);
   --color-accent: var(--accent-color);
   --color-accent-hover: var(--accent-hover-color);
+  --color-focus: var(--focus-color);
   --color-cta: var(--cta-color);
 
   /* Font families (spec §2.2)

--- a/tests/color-contrast.test.mjs
+++ b/tests/color-contrast.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { extname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = new URL("../", import.meta.url);
+const projectPath = fileURLToPath(projectRoot);
+const globalStyles = readFileSync(new URL("styles/globals.css", projectRoot), "utf8");
+
+function extractBlock(source, selector) {
+  const start = source.indexOf(selector);
+  assert.notEqual(start, -1, `Missing CSS block: ${selector}`);
+
+  const openingBrace = source.indexOf("{", start);
+  let depth = 0;
+
+  for (let index = openingBrace; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(openingBrace + 1, index);
+  }
+
+  throw new Error(`Unclosed CSS block: ${selector}`);
+}
+
+function readVariable(block, name) {
+  const match = block.match(new RegExp(`${name}\\s*:\\s*([^;]+);`, "i"));
+  assert.ok(match, `Missing CSS variable: ${name}`);
+  return match[1].trim();
+}
+
+function resolveVariable(name, primaryBlock, fallbackBlock = primaryBlock, seen = new Set()) {
+  assert.ok(!seen.has(name), `Circular CSS variable reference: ${name}`);
+  seen.add(name);
+
+  const primaryMatch = primaryBlock.match(new RegExp(`${name}\\s*:\\s*([^;]+);`, "i"));
+  const value = primaryMatch ? primaryMatch[1].trim() : readVariable(fallbackBlock, name);
+  const reference = value.match(/^var\((--[a-z0-9-]+)\)$/i);
+
+  return reference
+    ? resolveVariable(reference[1], primaryBlock, fallbackBlock, seen)
+    : value;
+}
+
+function relativeLuminance(hex) {
+  const channels = hex
+    .replace("#", "")
+    .match(/.{2}/g)
+    .map((channel) => Number.parseInt(channel, 16) / 255)
+    .map((channel) =>
+      channel <= 0.04045
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+
+  return (0.2126 * channels[0]) + (0.7152 * channels[1]) + (0.0722 * channels[2]);
+}
+
+function contrastRatio(foreground, background) {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function sourceFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return [".ts", ".tsx", ".css"].includes(extname(entry.name)) ? [path] : [];
+  });
+}
+
+const rootBlock = extractBlock(globalStyles, "\n  :root {");
+const darkBlock = extractBlock(globalStyles, "\n  .dark {");
+
+test("light-theme green foreground roles meet WCAG AA", () => {
+  const background = resolveVariable("--bg-primary", rootBlock);
+  const accessibleGreen = resolveVariable("--brand-green-foreground", rootBlock);
+  const accent = resolveVariable("--accent-color", rootBlock);
+  const accentHover = resolveVariable("--accent-hover-color", rootBlock);
+  const focus = resolveVariable("--focus-color", rootBlock);
+
+  assert.equal(accessibleGreen.toUpperCase(), "#037B40");
+  assert.equal(accent, accessibleGreen);
+  assert.equal(focus, accessibleGreen);
+  assert.ok(contrastRatio(accent, background) >= 4.5);
+  assert.ok(contrastRatio(accentHover, background) >= 4.5);
+  assert.ok(contrastRatio(focus, background) >= 4.5);
+});
+
+test("dark-theme identity accent remains bright and accessible", () => {
+  const background = resolveVariable("--bg-primary", darkBlock, rootBlock);
+  const accessibleGreen = resolveVariable("--brand-green-foreground", darkBlock, rootBlock);
+  const brightGreen = resolveVariable("--brand-green-bright", darkBlock, rootBlock);
+  const accent = resolveVariable("--accent-color", darkBlock, rootBlock);
+  const focus = resolveVariable("--focus-color", darkBlock, rootBlock);
+
+  assert.equal(accessibleGreen.toUpperCase(), "#037B40");
+  assert.equal(brightGreen.toUpperCase(), "#2BCC73");
+  assert.equal(accent, brightGreen);
+  assert.equal(focus, brightGreen);
+  assert.ok(contrastRatio(accent, background) >= 4.5);
+  assert.ok(contrastRatio(focus, background) >= 4.5);
+});
+
+test("foreground and focus utilities do not use the static bright token", () => {
+  const violations = ["app", "components"]
+    .flatMap((directory) => sourceFiles(join(projectPath, directory)))
+    .flatMap((path) => {
+      const source = readFileSync(path, "utf8");
+      return /(?:text|focus(?:-visible)?:(?:outline|ring))-brand-green-bright/.test(source)
+        ? [path]
+        : [];
+    });
+
+  assert.deepEqual(violations, []);
+});

--- a/tests/color-contrast.test.mjs
+++ b/tests/color-contrast.test.mjs
@@ -6,7 +6,10 @@ import { fileURLToPath } from "node:url";
 
 const projectRoot = new URL("../", import.meta.url);
 const projectPath = fileURLToPath(projectRoot);
-const globalStyles = readFileSync(new URL("styles/globals.css", projectRoot), "utf8");
+const globalStyles = readFileSync(
+  new URL("styles/globals.css", projectRoot),
+  "utf8",
+);
 
 function extractBlock(source, selector) {
   const start = source.indexOf(selector);
@@ -30,12 +33,21 @@ function readVariable(block, name) {
   return match[1].trim();
 }
 
-function resolveVariable(name, primaryBlock, fallbackBlock = primaryBlock, seen = new Set()) {
+function resolveVariable(
+  name,
+  primaryBlock,
+  fallbackBlock = primaryBlock,
+  seen = new Set(),
+) {
   assert.ok(!seen.has(name), `Circular CSS variable reference: ${name}`);
   seen.add(name);
 
-  const primaryMatch = primaryBlock.match(new RegExp(`${name}\\s*:\\s*([^;]+);`, "i"));
-  const value = primaryMatch ? primaryMatch[1].trim() : readVariable(fallbackBlock, name);
+  const primaryMatch = primaryBlock.match(
+    new RegExp(`${name}\\s*:\\s*([^;]+);`, "i"),
+  );
+  const value = primaryMatch
+    ? primaryMatch[1].trim()
+    : readVariable(fallbackBlock, name);
   const reference = value.match(/^var\((--[a-z0-9-]+)\)$/i);
 
   return reference
@@ -49,17 +61,21 @@ function relativeLuminance(hex) {
     .match(/.{2}/g)
     .map((channel) => Number.parseInt(channel, 16) / 255)
     .map((channel) =>
-      channel <= 0.04045
-        ? channel / 12.92
-        : ((channel + 0.055) / 1.055) ** 2.4,
+      channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
     );
 
-  return (0.2126 * channels[0]) + (0.7152 * channels[1]) + (0.0722 * channels[2]);
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
 }
 
 function contrastRatio(foreground, background) {
-  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
-  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  const lighter = Math.max(
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  );
+  const darker = Math.min(
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  );
   return (lighter + 0.05) / (darker + 0.05);
 }
 
@@ -76,7 +92,10 @@ const darkBlock = extractBlock(globalStyles, "\n  .dark {");
 
 test("light-theme green foreground roles meet WCAG AA", () => {
   const background = resolveVariable("--bg-primary", rootBlock);
-  const accessibleGreen = resolveVariable("--brand-green-foreground", rootBlock);
+  const accessibleGreen = resolveVariable(
+    "--brand-green-foreground",
+    rootBlock,
+  );
   const accent = resolveVariable("--accent-color", rootBlock);
   const accentHover = resolveVariable("--accent-hover-color", rootBlock);
   const focus = resolveVariable("--focus-color", rootBlock);
@@ -91,8 +110,16 @@ test("light-theme green foreground roles meet WCAG AA", () => {
 
 test("dark-theme identity accent remains bright and accessible", () => {
   const background = resolveVariable("--bg-primary", darkBlock, rootBlock);
-  const accessibleGreen = resolveVariable("--brand-green-foreground", darkBlock, rootBlock);
-  const brightGreen = resolveVariable("--brand-green-bright", darkBlock, rootBlock);
+  const accessibleGreen = resolveVariable(
+    "--brand-green-foreground",
+    darkBlock,
+    rootBlock,
+  );
+  const brightGreen = resolveVariable(
+    "--brand-green-bright",
+    darkBlock,
+    rootBlock,
+  );
   const accent = resolveVariable("--accent-color", darkBlock, rootBlock);
   const focus = resolveVariable("--focus-color", darkBlock, rootBlock);
 
@@ -104,12 +131,30 @@ test("dark-theme identity accent remains bright and accessible", () => {
   assert.ok(contrastRatio(focus, background) >= 4.5);
 });
 
+test("accent-filled controls use a foreground that passes in each theme", () => {
+  const lightAccent = resolveVariable("--accent-color", rootBlock);
+  const darkAccent = resolveVariable("--accent-color", darkBlock, rootBlock);
+
+  assert.ok(contrastRatio("#FFFFFF", lightAccent) >= 4.5);
+  assert.ok(contrastRatio("#000000", darkAccent) >= 4.5);
+
+  for (const relativePath of [
+    "components/blog/Pagination.tsx",
+    "components/ui/SkipLink.tsx",
+  ]) {
+    const source = readFileSync(join(projectPath, relativePath), "utf8");
+    assert.match(source, /bg-accent[^"\n]*text-white[^"\n]*dark:text-black/);
+  }
+});
+
 test("foreground and focus utilities do not use the static bright token", () => {
   const violations = ["app", "components"]
     .flatMap((directory) => sourceFiles(join(projectPath, directory)))
     .flatMap((path) => {
       const source = readFileSync(path, "utf8");
-      return /(?:text|focus(?:-visible)?:(?:outline|ring))-brand-green-bright/.test(source)
+      return /(?:text|focus(?:-visible)?:(?:outline|ring))-brand-green-bright/.test(
+        source,
+      )
         ? [path]
         : [];
     });


### PR DESCRIPTION
Closes #35. Adds semantic light/dark green foreground and focus tokens, updates consumers and the specification, and adds automated contrast regression coverage. Verified with npm test, npm run lint, npx tsc --noEmit, npm run build, and rendered light/dark visual QA.