### PR TITLE
security(cms): implement staff authorization and audited mutations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,4 +26,10 @@ NEXT_PUBLIC_FIREBASE_APP_ID=1:660220401300:web:9c1db908200c18e0458681
 # Server-only CMS authorization. Never expose these values with NEXT_PUBLIC_.
 FIREBASE_PROJECT_ID=shruggie-web
 FIREBASE_STORAGE_BUCKET=shruggie-web.firebasestorage.app
+# Comma-separated, verified Google account emails. Administrators can inspect
+# the audit stream; editors can create and change articles and assets.
 CMS_EDITOR_EMAILS=
+CMS_ADMIN_EMAILS=
+# Override only for local emulator work, for example http://localhost:3000.
+# Production defaults to NEXT_PUBLIC_SITE_URL and requires HTTPS.
+CMS_CANONICAL_ORIGIN=

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The versioned article, Markdown, asset, error, and export contracts are in
 Production dependency audit policy and the temporary Firebase advisory record
 are in
 [`docs/operations/dependency-security.md`](docs/operations/dependency-security.md).
+Staff identity, session, authorization, mutation, and audit controls are in
+[`docs/operations/editorial-security.md`](docs/operations/editorial-security.md).
 
 ## Getting Started
 

--- a/app/api/admin/articles/[id]/route.ts
+++ b/app/api/admin/articles/[id]/route.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+import { articleSchemaV1, editorialIdSchema } from "@/lib/editorial/domain";
+import { EditorialValidationError } from "@/lib/editorial/errors";
+import { createFirebaseEditorialBackend } from "@/lib/editorial/firebase-admin";
+import {
+  editorialErrorResponse,
+  editorialJson,
+  readStrictJson,
+  requireEditor,
+} from "@/lib/editorial/http";
+import {
+  assertCanonicalMutationOrigin,
+  loadEditorialSecurityConfig,
+  mutationContextFor,
+} from "@/lib/editorial/security";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const updateRequestSchema = z
+  .object({
+    article: articleSchemaV1,
+    expectedRevision: z.number().int().positive(),
+    idempotencyKey: z.string(),
+  })
+  .strict();
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, context: RouteContext) {
+  try {
+    await requireEditor(request);
+    const id = editorialIdSchema.parse((await context.params).id);
+    const article = await createFirebaseEditorialBackend().articles.getById(
+      id,
+      "all",
+    );
+    if (!article) {
+      return editorialJson(
+        { error: { code: "NOT_FOUND", message: "Article not found." } },
+        { status: 404 },
+      );
+    }
+    return editorialJson({ article });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  try {
+    const config = loadEditorialSecurityConfig();
+    assertCanonicalMutationOrigin(
+      request.headers.get("origin"),
+      config.canonicalOrigin,
+    );
+    const principal = await requireEditor(request);
+    const id = editorialIdSchema.parse((await context.params).id);
+    const body = updateRequestSchema.parse(await readStrictJson(request));
+    if (body.article.id !== id) {
+      throw new EditorialValidationError(
+        "The route and article IDs must match.",
+      );
+    }
+    const article = await createFirebaseEditorialBackend().articles.update({
+      ...body,
+      mutation: mutationContextFor(
+        principal,
+        request.headers.get("x-request-id"),
+      ),
+    });
+    return editorialJson({ article });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}

--- a/app/api/admin/articles/route.ts
+++ b/app/api/admin/articles/route.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+import { articleSchemaV1 } from "@/lib/editorial/domain";
+import { createFirebaseEditorialBackend } from "@/lib/editorial/firebase-admin";
+import {
+  editorialErrorResponse,
+  editorialJson,
+  readStrictJson,
+  requireEditor,
+} from "@/lib/editorial/http";
+import {
+  assertCanonicalMutationOrigin,
+  loadEditorialSecurityConfig,
+  mutationContextFor,
+} from "@/lib/editorial/security";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const createRequestSchema = z
+  .object({
+    article: articleSchemaV1,
+    idempotencyKey: z.string(),
+  })
+  .strict();
+
+export async function GET(request: Request) {
+  try {
+    await requireEditor(request);
+    const url = new URL(request.url);
+    const limitValue = url.searchParams.get("limit");
+    const limit = limitValue === null ? undefined : Number(limitValue);
+    const articles = await createFirebaseEditorialBackend().articles.list({
+      limit,
+      visibility: "all",
+    });
+    return editorialJson({ articles });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const config = loadEditorialSecurityConfig();
+    assertCanonicalMutationOrigin(
+      request.headers.get("origin"),
+      config.canonicalOrigin,
+    );
+    const principal = await requireEditor(request);
+    const body = createRequestSchema.parse(await readStrictJson(request));
+    const article = await createFirebaseEditorialBackend().articles.create({
+      ...body,
+      mutation: mutationContextFor(
+        principal,
+        request.headers.get("x-request-id"),
+      ),
+    });
+    return editorialJson({ article }, { status: 201 });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}

--- a/app/api/admin/assets/route.ts
+++ b/app/api/admin/assets/route.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+import { editorialIdSchema, MAX_ASSET_BYTES } from "@/lib/editorial/domain";
+import { EditorialValidationError } from "@/lib/editorial/errors";
+import { createFirebaseEditorialBackend } from "@/lib/editorial/firebase-admin";
+import {
+  editorialErrorResponse,
+  editorialJson,
+  requireEditor,
+} from "@/lib/editorial/http";
+import {
+  assertCanonicalMutationOrigin,
+  loadEditorialSecurityConfig,
+} from "@/lib/editorial/security";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const assetFieldsSchema = z
+  .object({
+    altText: z.string().trim().min(5).max(300),
+    articleId: editorialIdSchema,
+    id: editorialIdSchema,
+  })
+  .strict();
+
+const allowedFormFields = new Set(["altText", "articleId", "file", "id"]);
+
+export async function GET(request: Request) {
+  try {
+    await requireEditor(request);
+    const assets = await createFirebaseEditorialBackend().assets.exportAll();
+    return editorialJson({ assets });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const config = loadEditorialSecurityConfig();
+    assertCanonicalMutationOrigin(
+      request.headers.get("origin"),
+      config.canonicalOrigin,
+    );
+    const principal = await requireEditor(request);
+    const form = await request.formData();
+    for (const key of form.keys()) {
+      if (!allowedFormFields.has(key) || form.getAll(key).length !== 1) {
+        throw new EditorialValidationError(
+          "The asset upload contains unknown or duplicate fields.",
+        );
+      }
+    }
+    const file = form.get("file");
+    if (!(file instanceof File)) {
+      throw new EditorialValidationError("An image file is required.");
+    }
+    if (file.size > MAX_ASSET_BYTES) {
+      throw new EditorialValidationError(
+        `Image files must not exceed ${MAX_ASSET_BYTES} bytes.`,
+      );
+    }
+    const fields = assetFieldsSchema.parse({
+      altText: form.get("altText"),
+      articleId: form.get("articleId"),
+      id: form.get("id"),
+    });
+    const asset = await createFirebaseEditorialBackend().assets.put({
+      ...fields,
+      bytes: new Uint8Array(await file.arrayBuffer()),
+      contentType: file.type,
+      createdAt: new Date().toISOString(),
+      createdBy: principal.id,
+      fileName: file.name,
+    });
+    return editorialJson({ asset }, { status: 201 });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}

--- a/app/api/admin/audit/route.ts
+++ b/app/api/admin/audit/route.ts
@@ -1,0 +1,22 @@
+import { createFirebaseEditorialBackend } from "@/lib/editorial/firebase-admin";
+import {
+  editorialErrorResponse,
+  editorialJson,
+  requireEditor,
+} from "@/lib/editorial/http";
+import { requireEditorialRole } from "@/lib/editorial/security";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  try {
+    const principal = await requireEditor(request);
+    requireEditorialRole(principal, "admin");
+    const events =
+      await createFirebaseEditorialBackend().articles.exportAudit();
+    return editorialJson({ events });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}

--- a/app/api/admin/session/route.ts
+++ b/app/api/admin/session/route.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+import {
+  editorialErrorResponse,
+  editorialJson,
+  readStrictJson,
+} from "@/lib/editorial/http";
+import { getFirebaseEditorialAuth } from "@/lib/editorial/firebase-admin";
+import {
+  assertCanonicalMutationOrigin,
+  clearEditorSessionCookie,
+  createEditorSessionCookie,
+  EDITOR_SESSION_MAX_AGE_MS,
+  loadEditorialSecurityConfig,
+  revokeEditorSessions,
+  serializeEditorSessionCookie,
+  verifyEditorIdToken,
+  verifyEditorSession,
+} from "@/lib/editorial/security";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const sessionRequestSchema = z
+  .object({ idToken: z.string().trim().min(1).max(16_384) })
+  .strict();
+
+export async function GET(request: Request) {
+  try {
+    const principal = await verifyEditorSession(
+      request.headers.get("cookie"),
+      getFirebaseEditorialAuth(),
+      loadEditorialSecurityConfig(),
+    );
+    return editorialJson({
+      editor: { id: principal.id, role: principal.role },
+    });
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const config = loadEditorialSecurityConfig();
+    assertCanonicalMutationOrigin(
+      request.headers.get("origin"),
+      config.canonicalOrigin,
+    );
+    const body = sessionRequestSchema.parse(await readStrictJson(request));
+    const auth = getFirebaseEditorialAuth();
+    const principal = await verifyEditorIdToken(body.idToken, auth, config);
+    const sessionCookie = await createEditorSessionCookie(body.idToken, auth);
+    return editorialJson(
+      { editor: { id: principal.id, role: principal.role } },
+      {
+        headers: {
+          "Set-Cookie": serializeEditorSessionCookie(
+            sessionCookie,
+            EDITOR_SESSION_MAX_AGE_MS / 1000,
+          ),
+        },
+      },
+    );
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}
+
+export async function DELETE(request: Request) {
+  let clearLocalSession = false;
+  try {
+    const config = loadEditorialSecurityConfig();
+    assertCanonicalMutationOrigin(
+      request.headers.get("origin"),
+      config.canonicalOrigin,
+    );
+    const auth = getFirebaseEditorialAuth();
+    const principal = await verifyEditorSession(
+      request.headers.get("cookie"),
+      auth,
+      config,
+    );
+    clearLocalSession = true;
+    await revokeEditorSessions(principal.uid, auth);
+    return editorialJson(
+      { signedOut: true },
+      { headers: { "Set-Cookie": clearEditorSessionCookie() } },
+    );
+  } catch (error) {
+    const response = editorialErrorResponse(error);
+    if (clearLocalSession) {
+      response.headers.set("Set-Cookie", clearEditorSessionCookie());
+    }
+    return response;
+  }
+}

--- a/docs/editorial/content-contract.md
+++ b/docs/editorial/content-contract.md
@@ -73,10 +73,13 @@ uses `MdxArticleReader`, which validates repository frontmatter and Markdown
 through article schema v1. Firebase SDK objects never cross this boundary.
 
 `FirestoreArticleRepository` implements transactional creates and updates over
-the `articles`, `articleSlugs`, `articleRevisions`, and `idempotencyKeys`
-collections. `FirebaseAssetStore` validates bytes before writing private objects
-and records. Both modules are marked server-only and translate provider failures
-into project errors.
+the `articles`, `articleSlugs`, `articleRevisions`, `idempotencyKeys`, and
+`editorialAudit` collections. Every create or update command carries the
+verified pseudonymous actor, bounded role, and request ID; the repository
+rejects a revision that attributes the write to a different actor.
+`FirebaseAssetStore` validates bytes before writing private objects and records.
+Both modules are marked server-only and translate provider failures into
+project errors.
 
 | Error code                 | Meaning                                           | Retryable |
 | -------------------------- | ------------------------------------------------- | --------- |

--- a/docs/operations/editorial-security.md
+++ b/docs/operations/editorial-security.md
@@ -1,0 +1,96 @@
+# Editorial security operations
+
+Issue [#26](https://github.com/shruggietech/shruggie-web/issues/26)
+establishes the staff-only boundary for the browser editorial platform.
+
+## Identity and roles
+
+Firebase Authentication proves identity, but authorization remains an explicit
+server-side ShruggieTech decision. Configure verified Google account emails in
+the Vercel production environment:
+
+```text
+CMS_EDITOR_EMAILS=editor-one@example.com,editor-two@example.com
+CMS_ADMIN_EMAILS=admin@example.com
+```
+
+Both lists are case-insensitive. Editors may read drafts and create or update
+articles and assets. Administrators have the same content permissions and may
+also inspect the editorial audit stream. Neither role may manage the allowlist
+from the browser. Removing an email denies its next verified request; use the
+Firebase console or Admin SDK to revoke existing refresh tokens when access
+must end immediately.
+
+Raw email addresses are used only for the in-memory allowlist comparison. The
+application derives a stable `editor:<sha256>` identifier from the Firebase UID
+for article revisions and audit records, so content history does not retain an
+email address.
+
+## Session boundary
+
+`POST /api/admin/session` accepts a recently authenticated Firebase ID token
+from the future #27 sign-in interface. The server checks token revocation,
+verified email status, the allowlist, and a five-minute maximum authentication
+age before issuing an eight-hour Firebase session cookie. The cookie is
+HTTP-only, Secure, `SameSite=Strict`, host-only, and scoped to `/`.
+
+Every protected request verifies the session cookie with revocation checking.
+`DELETE /api/admin/session` revokes the account's refresh tokens and clears the
+local cookie. Expired, revoked, disabled, removed, or malformed identities fail
+closed. Firebase authentication outages return a retryable 503 response and do
+not expose draft data.
+
+## Request boundary
+
+All article and asset mutations require an `Origin` header that exactly matches
+`CMS_CANONICAL_ORIGIN`, or `NEXT_PUBLIC_SITE_URL` when no override is present.
+Non-local origins must use HTTPS. Session cookies also use strict same-site
+policy. Request bodies use strict Zod schemas, unknown JSON or multipart fields
+are rejected, and response bodies never include credentials or raw provider
+errors.
+
+The protected server routes are:
+
+| Route                     | Method          | Required role | Purpose                         |
+| ------------------------- | --------------- | ------------- | ------------------------------- |
+| `/api/admin/session`      | GET/POST/DELETE | staff         | Inspect, create, or end session |
+| `/api/admin/articles`     | GET/POST        | editor        | List drafts or create article   |
+| `/api/admin/articles/:id` | GET/PUT         | editor        | Read or update an article       |
+| `/api/admin/assets`       | GET/POST        | editor        | List or upload private assets   |
+| `/api/admin/audit`        | GET             | administrator | Inspect redacted audit events   |
+
+Browser Firebase SDK access to Firestore and Storage remains denied by
+`firestore.rules` and `storage.rules`. Only authenticated Next.js Node.js route
+handlers use Firebase Admin.
+
+## Concurrency, replay, and audit
+
+Every article mutation requires a 16–128 character idempotency key and the
+expected current revision for updates. The repository includes the verified
+actor and role in the idempotency fingerprint, rejects key reuse with different
+content or authority, and rejects stale revisions before writing. A retried
+request may carry a new correlation ID without defeating idempotent replay.
+
+The article, immutable revision, idempotency record, and immutable
+`editorialAudit` event are committed in one Firestore transaction. Events use a
+deterministic ID derived from the idempotency key and record only the
+pseudonymous actor ID, bounded role, request ID, article ID/revision, server
+timestamp, and one of `create`, `edit`, `publish`, `unpublish`, `archive`, or
+`restore`. Replaying an identical successful request returns its original
+revision without producing a second audit event.
+
+## Production activation checklist
+
+1. Configure `CMS_EDITOR_EMAILS` and `CMS_ADMIN_EMAILS` in Vercel production.
+2. Deploy the application and confirm the protected routes deny anonymous,
+   unapproved, cross-origin, expired, and revoked requests.
+3. Confirm Firestore and Storage rules still deny all browser SDK access.
+4. Enable only the Google sign-in provider in Firebase Authentication and keep
+   public registration absent from the application.
+5. Confirm Firebase authorized domains contain only the production and required
+   Firebase authentication handler domains.
+6. Sign in with one editor and one administrator, verify role boundaries, then
+   revoke the test sessions.
+
+Do not enable the production sign-in provider until the allowlists are known
+and steps 1–3 are deployed.

--- a/docs/operations/firebase-production.md
+++ b/docs/operations/firebase-production.md
@@ -60,10 +60,12 @@ mandatory.
 ## Authentication gate
 
 Firebase Authentication is initialized, but no sign-in provider is enabled.
-Issue #26 must establish token verification, revocation checks, the explicit
-server-side editor allowlist, and canonical-origin enforcement before enabling
-a production provider. The `/admin` experience must never expose public
-registration.
+The server boundary from issue #26 verifies revoked tokens and session cookies,
+enforces explicit editor and administrator allowlists, and rejects mutations
+outside the canonical origin. Configure the production allowlists and complete
+the activation checklist in
+[`editorial-security.md`](editorial-security.md) before enabling Google sign-in.
+The `/admin` experience must never expose public registration.
 
 ## Recovery checks
 

--- a/lib/editorial/audit.ts
+++ b/lib/editorial/audit.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+
+import type { Article } from "./domain";
+import { editorialIdSchema } from "./domain";
+import { EditorialValidationError } from "./errors";
+
+export const editorialRoleSchema = z.enum(["editor", "admin"]);
+
+export const editorialMutationContextSchema = z
+  .object({
+    actorId: editorialIdSchema,
+    requestId: z
+      .string()
+      .trim()
+      .min(16)
+      .max(128)
+      .regex(/^[A-Za-z0-9:_-]+$/),
+    role: editorialRoleSchema,
+  })
+  .strict();
+
+export const editorialAuditActionSchema = z.enum([
+  "create",
+  "edit",
+  "publish",
+  "unpublish",
+  "archive",
+  "restore",
+]);
+
+export const editorialAuditEventSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    id: editorialIdSchema,
+    action: editorialAuditActionSchema,
+    actorId: editorialIdSchema,
+    actorRole: editorialRoleSchema,
+    articleId: editorialIdSchema,
+    articleRevision: z.number().int().positive(),
+    occurredAt: z.string().datetime({ offset: true }),
+    requestId: z.string().min(16).max(128),
+  })
+  .strict();
+
+export type EditorialRole = z.infer<typeof editorialRoleSchema>;
+export type EditorialMutationContext = z.infer<
+  typeof editorialMutationContextSchema
+>;
+export type EditorialAuditAction = z.infer<typeof editorialAuditActionSchema>;
+export type EditorialAuditEvent = z.infer<typeof editorialAuditEventSchema>;
+
+export function parseEditorialAuditEvent(input: unknown): EditorialAuditEvent {
+  const result = editorialAuditEventSchema.safeParse(input);
+  if (!result.success) {
+    throw new EditorialValidationError("Editorial audit record is invalid.", {
+      issues: result.error.issues,
+    });
+  }
+  return result.data;
+}
+
+export function parseEditorialMutationContext(
+  input: unknown,
+): EditorialMutationContext {
+  const result = editorialMutationContextSchema.safeParse(input);
+  if (!result.success) {
+    throw new EditorialValidationError("Mutation context is invalid.", {
+      issues: result.error.issues,
+    });
+  }
+  return result.data;
+}
+
+export function deriveAuditAction(
+  previous: Article | null,
+  next: Article,
+): EditorialAuditAction {
+  if (!previous) return "create";
+  if (previous.state === "archived" && next.state === "draft") {
+    return "restore";
+  }
+  if (next.state === "archived" && previous.state !== "archived") {
+    return "archive";
+  }
+  if (previous.state !== "published" && next.state === "published") {
+    return "publish";
+  }
+  if (previous.state === "published" && next.state === "draft") {
+    return "unpublish";
+  }
+  return "edit";
+}
+
+export function createAuditEvent(
+  id: string,
+  previous: Article | null,
+  next: Article,
+  context: EditorialMutationContext,
+): EditorialAuditEvent {
+  const parsedContext = parseEditorialMutationContext(context);
+  if (next.revision.updatedBy !== parsedContext.actorId) {
+    throw new EditorialValidationError(
+      "The article revision editor must match the authorized actor.",
+      {
+        actorId: parsedContext.actorId,
+        updatedBy: next.revision.updatedBy,
+      },
+    );
+  }
+  return editorialAuditEventSchema.parse({
+    schemaVersion: 1,
+    id,
+    action: deriveAuditAction(previous, next),
+    actorId: parsedContext.actorId,
+    actorRole: parsedContext.role,
+    articleId: next.id,
+    articleRevision: next.revision.number,
+    occurredAt: new Date().toISOString(),
+    requestId: parsedContext.requestId,
+  });
+}

--- a/lib/editorial/firebase-admin.ts
+++ b/lib/editorial/firebase-admin.ts
@@ -9,6 +9,7 @@ import {
 } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
+import { getAuth } from "firebase-admin/auth";
 import { z } from "zod";
 
 import { FirebaseAssetStore } from "./firebase-asset-store";
@@ -60,4 +61,8 @@ export function createFirebaseEditorialBackend() {
       environment.NEXT_PUBLIC_SITE_URL,
     ),
   };
+}
+
+export function getFirebaseEditorialAuth() {
+  return getAuth(firebaseAdminApp());
 }

--- a/lib/editorial/firestore-article-repository.ts
+++ b/lib/editorial/firestore-article-repository.ts
@@ -11,6 +11,12 @@ import type {
 import { Timestamp } from "firebase-admin/firestore";
 
 import {
+  createAuditEvent,
+  parseEditorialAuditEvent,
+  parseEditorialMutationContext,
+  type EditorialAuditEvent,
+} from "./audit";
+import {
   articleSlugSchema,
   editorialIdSchema,
   parseArticle,
@@ -35,6 +41,7 @@ import { assertArticleMutation } from "./transitions";
 const ARTICLES = "articles";
 const ARTICLE_SLUGS = "articleSlugs";
 const ARTICLE_REVISIONS = "articleRevisions";
+const EDITORIAL_AUDIT = "editorialAudit";
 const IDEMPOTENCY_KEYS = "idempotencyKeys";
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
@@ -53,6 +60,10 @@ function revisionDocumentId(article: Article): string {
   return `${article.id}:${article.revision.number.toString().padStart(10, "0")}`;
 }
 
+function auditDocumentId(idempotencyKey: string): string {
+  return `audit:${fingerprint(idempotencyKey).slice(0, 40)}`;
+}
+
 export class FirestoreArticleRepository implements ArticleRepository {
   constructor(
     private readonly db: Firestore,
@@ -67,7 +78,12 @@ export class FirestoreArticleRepository implements ArticleRepository {
       );
     }
     const idempotencyKey = validateIdempotencyKey(command.idempotencyKey);
-    const commandFingerprint = fingerprint(article);
+    const mutation = parseEditorialMutationContext(command.mutation);
+    const commandFingerprint = fingerprint({
+      actorId: mutation.actorId,
+      article,
+      role: mutation.role,
+    });
 
     return withEditorialTimeout("create an article", this.timeoutMs, () =>
       this.db.runTransaction(async (transaction) => {
@@ -114,6 +130,17 @@ export class FirestoreArticleRepository implements ArticleRepository {
           commandFingerprint,
           article,
         );
+        transaction.create(
+          this.db
+            .collection(EDITORIAL_AUDIT)
+            .doc(auditDocumentId(idempotencyKey)),
+          createAuditEvent(
+            auditDocumentId(idempotencyKey),
+            null,
+            article,
+            mutation,
+          ),
+        );
         return article;
       }),
     );
@@ -122,9 +149,12 @@ export class FirestoreArticleRepository implements ArticleRepository {
   async update(command: UpdateArticleCommand): Promise<Article> {
     const next = parseArticle(command.article);
     const idempotencyKey = validateIdempotencyKey(command.idempotencyKey);
+    const mutation = parseEditorialMutationContext(command.mutation);
     const commandFingerprint = fingerprint({
       article: next,
+      actorId: mutation.actorId,
       expectedRevision: command.expectedRevision,
+      role: mutation.role,
     });
 
     return withEditorialTimeout("update an article", this.timeoutMs, () =>
@@ -171,6 +201,17 @@ export class FirestoreArticleRepository implements ArticleRepository {
           idempotencyKey,
           commandFingerprint,
           next,
+        );
+        transaction.create(
+          this.db
+            .collection(EDITORIAL_AUDIT)
+            .doc(auditDocumentId(idempotencyKey)),
+          createAuditEvent(
+            auditDocumentId(idempotencyKey),
+            current,
+            next,
+            mutation,
+          ),
         );
         return next;
       }),
@@ -259,6 +300,22 @@ export class FirestoreArticleRepository implements ArticleRepository {
         .get();
       return snapshot.docs.map((document) => parseArticle(document.data()));
     });
+  }
+
+  async exportAudit(): Promise<EditorialAuditEvent[]> {
+    return withEditorialTimeout(
+      "export editorial audit records",
+      this.timeoutMs,
+      async () => {
+        const snapshot = await this.db
+          .collection(EDITORIAL_AUDIT)
+          .orderBy("__name__")
+          .get();
+        return snapshot.docs.map((document) =>
+          parseEditorialAuditEvent(document.data()),
+        );
+      },
+    );
   }
 
   private async readIdempotentReplay(

--- a/lib/editorial/http.ts
+++ b/lib/editorial/http.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+import { EditorialError, EditorialValidationError } from "./errors";
+import { getFirebaseEditorialAuth } from "./firebase-admin";
+import {
+  EditorialSecurityError,
+  loadEditorialSecurityConfig,
+  verifyEditorSession,
+  type EditorPrincipal,
+} from "./security";
+
+const noStoreHeaders = {
+  "Cache-Control": "private, no-store, max-age=0",
+  Vary: "Cookie",
+};
+
+export async function requireEditor(
+  request: Request,
+): Promise<EditorPrincipal> {
+  return verifyEditorSession(
+    request.headers.get("cookie"),
+    getFirebaseEditorialAuth(),
+    loadEditorialSecurityConfig(),
+  );
+}
+
+export async function readStrictJson(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch (error) {
+    throw new EditorialValidationError("The request body must be valid JSON.", {
+      cause: error instanceof Error ? error.name : "unknown",
+    });
+  }
+}
+
+export function editorialJson(
+  body: unknown,
+  init: ResponseInit = {},
+): NextResponse {
+  return NextResponse.json(body, {
+    ...init,
+    headers: { ...noStoreHeaders, ...init.headers },
+  });
+}
+
+export function editorialErrorResponse(error: unknown): NextResponse {
+  if (error instanceof EditorialSecurityError) {
+    return editorialJson(
+      { error: { code: error.code, message: error.message } },
+      { status: error.status },
+    );
+  }
+  if (error instanceof ZodError) {
+    return editorialJson(
+      {
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "The request payload is invalid.",
+          issues: error.issues.map((issue) => ({
+            message: issue.message,
+            path: issue.path,
+          })),
+        },
+      },
+      { status: 400 },
+    );
+  }
+  if (error instanceof EditorialError) {
+    const status =
+      error.code === "CONTENT_TIMEOUT"
+        ? 504
+        : error.code === "CONTENT_UNAVAILABLE"
+          ? 503
+          : error.code === "NOT_FOUND"
+            ? 404
+            : [
+                  "ASSET_COLLISION",
+                  "INVALID_STATE_TRANSITION",
+                  "REVISION_CONFLICT",
+                  "SLUG_COLLISION",
+                ].includes(error.code)
+              ? 409
+              : 400;
+    return editorialJson(
+      { error: { code: error.code, message: error.message } },
+      { status },
+    );
+  }
+  console.error("Unhandled editorial route error", error);
+  return editorialJson(
+    {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "The editorial request could not be completed.",
+      },
+    },
+    { status: 500 },
+  );
+}

--- a/lib/editorial/memory-adapter.ts
+++ b/lib/editorial/memory-adapter.ts
@@ -1,6 +1,13 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
+
 import { prepareAssetUpload } from "./assets";
+import {
+  createAuditEvent,
+  parseEditorialMutationContext,
+  type EditorialAuditEvent,
+} from "./audit";
 import {
   editorialIdSchema,
   parseArticle,
@@ -37,6 +44,7 @@ interface IdempotentResult {
 export class InMemoryArticleRepository implements ArticleRepository {
   private readonly articles = new Map<string, Article>();
   private readonly articleIdBySlug = new Map<string, string>();
+  private readonly auditEvents = new Map<string, EditorialAuditEvent>();
   private readonly idempotentResults = new Map<string, IdempotentResult>();
   private failureMode: FailureMode = "available";
 
@@ -61,8 +69,13 @@ export class InMemoryArticleRepository implements ArticleRepository {
   async create(command: CreateArticleCommand): Promise<Article> {
     this.assertAvailable("create an article");
     validateIdempotencyKey(command.idempotencyKey);
+    const mutation = parseEditorialMutationContext(command.mutation);
     const article = parseArticle(command.article);
-    const fingerprint = JSON.stringify(article);
+    const fingerprint = JSON.stringify({
+      actorId: mutation.actorId,
+      article,
+      role: mutation.role,
+    });
     const replay = this.getIdempotentReplay(
       command.idempotencyKey,
       fingerprint,
@@ -85,22 +98,28 @@ export class InMemoryArticleRepository implements ArticleRepository {
       throw new SlugCollisionError(article.slug, existingArticleId);
     }
 
+    const auditId = this.auditId(command.idempotencyKey);
+    const auditEvent = createAuditEvent(auditId, null, article, mutation);
     this.articles.set(article.id, structuredClone(article));
     this.articleIdBySlug.set(article.slug, article.id);
     this.idempotentResults.set(command.idempotencyKey, {
       articleId: article.id,
       fingerprint,
     });
+    this.auditEvents.set(auditId, auditEvent);
     return structuredClone(article);
   }
 
   async update(command: UpdateArticleCommand): Promise<Article> {
     this.assertAvailable("update an article");
     validateIdempotencyKey(command.idempotencyKey);
+    const mutation = parseEditorialMutationContext(command.mutation);
     const next = parseArticle(command.article);
     const fingerprint = JSON.stringify({
       article: next,
+      actorId: mutation.actorId,
       expectedRevision: command.expectedRevision,
+      role: mutation.role,
     });
     const replay = this.getIdempotentReplay(
       command.idempotencyKey,
@@ -111,6 +130,8 @@ export class InMemoryArticleRepository implements ArticleRepository {
     const current = this.articles.get(next.id);
     if (!current) throw new ArticleNotFoundError(next.id);
     assertArticleMutation(current, next, command.expectedRevision);
+    const auditId = this.auditId(command.idempotencyKey);
+    const auditEvent = createAuditEvent(auditId, current, next, mutation);
 
     if (current.slug !== next.slug) {
       const existingArticleId = this.articleIdBySlug.get(next.slug);
@@ -126,6 +147,7 @@ export class InMemoryArticleRepository implements ArticleRepository {
       articleId: next.id,
       fingerprint,
     });
+    this.auditEvents.set(auditId, auditEvent);
     return structuredClone(next);
   }
 
@@ -175,6 +197,21 @@ export class InMemoryArticleRepository implements ArticleRepository {
     return [...this.articles.values()].map((article) =>
       structuredClone(article),
     );
+  }
+
+  async exportAudit(): Promise<EditorialAuditEvent[]> {
+    this.assertAvailable("export editorial audit records");
+    return [...this.auditEvents.values()]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map((event) => structuredClone(event));
+  }
+
+  private auditId(idempotencyKey: string): string {
+    const digest = createHash("sha256")
+      .update(idempotencyKey)
+      .digest("hex")
+      .slice(0, 40);
+    return `audit:${digest}`;
   }
 
   private getIdempotentReplay(

--- a/lib/editorial/ports.ts
+++ b/lib/editorial/ports.ts
@@ -1,4 +1,5 @@
 import type { Article, AssetUploadInput, EditorialAsset } from "./domain";
+import type { EditorialAuditEvent, EditorialMutationContext } from "./audit";
 import { EditorialValidationError } from "./errors";
 
 export type ArticleVisibility = "all" | "published";
@@ -11,12 +12,14 @@ export interface ArticleListOptions {
 export interface CreateArticleCommand {
   article: Article;
   idempotencyKey: string;
+  mutation: EditorialMutationContext;
 }
 
 export interface UpdateArticleCommand {
   article: Article;
   expectedRevision: number;
   idempotencyKey: string;
+  mutation: EditorialMutationContext;
 }
 
 export interface ArticleReader {
@@ -30,6 +33,7 @@ export interface ArticleReader {
 
 export interface ArticleRepository extends ArticleReader {
   create(command: CreateArticleCommand): Promise<Article>;
+  exportAudit(): Promise<EditorialAuditEvent[]>;
   exportAll(): Promise<Article[]>;
   update(command: UpdateArticleCommand): Promise<Article>;
 }

--- a/lib/editorial/security.ts
+++ b/lib/editorial/security.ts
@@ -1,0 +1,348 @@
+import "server-only";
+
+import { createHash, randomUUID } from "node:crypto";
+
+import { z } from "zod";
+
+import {
+  editorialMutationContextSchema,
+  type EditorialMutationContext,
+  type EditorialRole,
+} from "./audit";
+
+export const EDITOR_SESSION_COOKIE = "__Host-shruggie_editor";
+export const EDITOR_SESSION_MAX_AGE_MS = 8 * 60 * 60 * 1000;
+const MAX_SIGN_IN_TOKEN_AGE_SECONDS = 5 * 60;
+
+export type EditorialSecurityErrorCode =
+  | "AUTH_UNAVAILABLE"
+  | "INVALID_ORIGIN"
+  | "INVALID_SESSION"
+  | "STALE_SIGN_IN"
+  | "UNAUTHENTICATED"
+  | "UNAUTHORIZED";
+
+export class EditorialSecurityError extends Error {
+  constructor(
+    readonly code: EditorialSecurityErrorCode,
+    message: string,
+    readonly status: 401 | 403 | 503,
+    options: { cause?: unknown } = {},
+  ) {
+    super(message, options);
+    this.name = "EditorialSecurityError";
+  }
+}
+
+export interface VerifiedFirebaseIdentity {
+  auth_time?: number;
+  email?: string;
+  email_verified?: boolean;
+  uid: string;
+}
+
+export interface EditorialAuthVerifier {
+  verifyIdToken(
+    token: string,
+    checkRevoked: boolean,
+  ): Promise<VerifiedFirebaseIdentity>;
+  verifySessionCookie(
+    cookie: string,
+    checkRevoked: boolean,
+  ): Promise<VerifiedFirebaseIdentity>;
+}
+
+export interface EditorialSessionAuth extends EditorialAuthVerifier {
+  createSessionCookie(
+    token: string,
+    options: { expiresIn: number },
+  ): Promise<string>;
+  revokeRefreshTokens(uid: string): Promise<void>;
+}
+
+export interface EditorialSecurityConfig {
+  adminEmails: ReadonlySet<string>;
+  canonicalOrigin: string;
+  editorEmails: ReadonlySet<string>;
+}
+
+export interface EditorPrincipal {
+  id: string;
+  role: EditorialRole;
+  uid: string;
+}
+
+const environmentSchema = z
+  .object({
+    CMS_ADMIN_EMAILS: z.string().optional().default(""),
+    CMS_CANONICAL_ORIGIN: z.string().optional(),
+    CMS_EDITOR_EMAILS: z.string().optional().default(""),
+    NEXT_PUBLIC_SITE_URL: z.string().min(1),
+  })
+  .strict();
+
+const requestIdSchema = editorialMutationContextSchema.shape.requestId;
+
+function parseEmailSet(value: string): ReadonlySet<string> {
+  return new Set(
+    value
+      .split(",")
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean)
+      .map((email) => z.string().email().parse(email)),
+  );
+}
+
+export function loadEditorialSecurityConfig(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): EditorialSecurityConfig {
+  const parsed = environmentSchema.parse({
+    CMS_ADMIN_EMAILS: environment.CMS_ADMIN_EMAILS,
+    CMS_CANONICAL_ORIGIN: environment.CMS_CANONICAL_ORIGIN,
+    CMS_EDITOR_EMAILS: environment.CMS_EDITOR_EMAILS,
+    NEXT_PUBLIC_SITE_URL: environment.NEXT_PUBLIC_SITE_URL,
+  });
+  const canonical = new URL(
+    parsed.CMS_CANONICAL_ORIGIN ?? parsed.NEXT_PUBLIC_SITE_URL,
+  );
+  const isLocal = ["localhost", "127.0.0.1", "::1"].includes(
+    canonical.hostname,
+  );
+  if (
+    canonical.protocol !== "https:" &&
+    !(isLocal && canonical.protocol === "http:")
+  ) {
+    throw new Error(
+      "The CMS canonical origin must use HTTPS outside localhost.",
+    );
+  }
+  return {
+    adminEmails: parseEmailSet(parsed.CMS_ADMIN_EMAILS),
+    canonicalOrigin: canonical.origin,
+    editorEmails: parseEmailSet(parsed.CMS_EDITOR_EMAILS),
+  };
+}
+
+function firebaseErrorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error
+    ? String((error as { code: unknown }).code)
+    : undefined;
+}
+
+function mapFirebaseAuthError(error: unknown): EditorialSecurityError {
+  const code = firebaseErrorCode(error);
+  if (
+    code &&
+    [
+      "auth/id-token-expired",
+      "auth/id-token-revoked",
+      "auth/invalid-id-token",
+      "auth/session-cookie-expired",
+      "auth/session-cookie-revoked",
+      "auth/user-disabled",
+      "auth/user-not-found",
+    ].includes(code)
+  ) {
+    return new EditorialSecurityError(
+      "INVALID_SESSION",
+      "The editorial session is invalid or expired.",
+      401,
+      { cause: error },
+    );
+  }
+  return new EditorialSecurityError(
+    "AUTH_UNAVAILABLE",
+    "Editorial authentication is temporarily unavailable.",
+    503,
+    { cause: error },
+  );
+}
+
+export async function createEditorSessionCookie(
+  token: string,
+  auth: EditorialSessionAuth,
+): Promise<string> {
+  try {
+    return await auth.createSessionCookie(token, {
+      expiresIn: EDITOR_SESSION_MAX_AGE_MS,
+    });
+  } catch (error) {
+    throw mapFirebaseAuthError(error);
+  }
+}
+
+export async function revokeEditorSessions(
+  uid: string,
+  auth: EditorialSessionAuth,
+): Promise<void> {
+  try {
+    await auth.revokeRefreshTokens(uid);
+  } catch (error) {
+    throw mapFirebaseAuthError(error);
+  }
+}
+
+function principalId(uid: string): string {
+  const digest = createHash("sha256").update(uid).digest("hex").slice(0, 32);
+  return `editor:${digest}`;
+}
+
+export function authorizeEditorIdentity(
+  identity: VerifiedFirebaseIdentity,
+  config: EditorialSecurityConfig,
+): EditorPrincipal {
+  const email = identity.email?.trim().toLowerCase();
+  if (!identity.uid || !email || identity.email_verified !== true) {
+    throw new EditorialSecurityError(
+      "UNAUTHORIZED",
+      "A verified, approved staff account is required.",
+      403,
+    );
+  }
+  const role = config.adminEmails.has(email)
+    ? "admin"
+    : config.editorEmails.has(email)
+      ? "editor"
+      : null;
+  if (!role) {
+    throw new EditorialSecurityError(
+      "UNAUTHORIZED",
+      "This account is not approved for editorial access.",
+      403,
+    );
+  }
+  return { id: principalId(identity.uid), role, uid: identity.uid };
+}
+
+export async function verifyEditorIdToken(
+  token: string,
+  verifier: EditorialAuthVerifier,
+  config: EditorialSecurityConfig,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<EditorPrincipal> {
+  if (!token.trim()) {
+    throw new EditorialSecurityError(
+      "UNAUTHENTICATED",
+      "A Firebase ID token is required.",
+      401,
+    );
+  }
+  let identity: VerifiedFirebaseIdentity;
+  try {
+    identity = await verifier.verifyIdToken(token, true);
+  } catch (error) {
+    throw mapFirebaseAuthError(error);
+  }
+  if (
+    typeof identity.auth_time !== "number" ||
+    nowSeconds - identity.auth_time > MAX_SIGN_IN_TOKEN_AGE_SECONDS ||
+    identity.auth_time > nowSeconds + 30
+  ) {
+    throw new EditorialSecurityError(
+      "STALE_SIGN_IN",
+      "Sign in again before starting an editorial session.",
+      401,
+    );
+  }
+  return authorizeEditorIdentity(identity, config);
+}
+
+function readCookie(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator < 0) continue;
+    if (part.slice(0, separator).trim() === name) {
+      return decodeURIComponent(part.slice(separator + 1).trim());
+    }
+  }
+  return null;
+}
+
+export async function verifyEditorSession(
+  cookieHeader: string | null,
+  verifier: EditorialAuthVerifier,
+  config: EditorialSecurityConfig,
+): Promise<EditorPrincipal> {
+  const sessionCookie = readCookie(cookieHeader, EDITOR_SESSION_COOKIE);
+  if (!sessionCookie) {
+    throw new EditorialSecurityError(
+      "UNAUTHENTICATED",
+      "An editorial session is required.",
+      401,
+    );
+  }
+  try {
+    const identity = await verifier.verifySessionCookie(sessionCookie, true);
+    return authorizeEditorIdentity(identity, config);
+  } catch (error) {
+    if (error instanceof EditorialSecurityError) throw error;
+    throw mapFirebaseAuthError(error);
+  }
+}
+
+export function assertCanonicalMutationOrigin(
+  originHeader: string | null,
+  canonicalOrigin: string,
+): void {
+  if (!originHeader) {
+    throw new EditorialSecurityError(
+      "INVALID_ORIGIN",
+      "Mutation requests require a canonical Origin header.",
+      403,
+    );
+  }
+  let origin: string;
+  try {
+    origin = new URL(originHeader).origin;
+  } catch {
+    throw new EditorialSecurityError(
+      "INVALID_ORIGIN",
+      "The request origin is invalid.",
+      403,
+    );
+  }
+  if (origin !== canonicalOrigin) {
+    throw new EditorialSecurityError(
+      "INVALID_ORIGIN",
+      "Cross-origin editorial mutations are not allowed.",
+      403,
+    );
+  }
+}
+
+export function mutationContextFor(
+  principal: EditorPrincipal,
+  requestIdHeader: string | null,
+): EditorialMutationContext {
+  const candidate = requestIdHeader ?? `request:${randomUUID()}`;
+  const requestId = requestIdSchema.safeParse(candidate);
+  return {
+    actorId: principal.id,
+    requestId: requestId.success ? requestId.data : `request:${randomUUID()}`,
+    role: principal.role,
+  };
+}
+
+export function requireEditorialRole(
+  principal: EditorPrincipal,
+  requiredRole: EditorialRole,
+): void {
+  if (requiredRole === "editor" || principal.role === "admin") return;
+  throw new EditorialSecurityError(
+    "UNAUTHORIZED",
+    "This editorial action requires an administrator.",
+    403,
+  );
+}
+
+export function serializeEditorSessionCookie(
+  value: string,
+  maxAgeSeconds: number,
+): string {
+  return `${EDITOR_SESSION_COOKIE}=${encodeURIComponent(value)}; Max-Age=${maxAgeSeconds}; Path=/; HttpOnly; Secure; SameSite=Strict`;
+}
+
+export function clearEditorSessionCookie(): string {
+  return `${EDITOR_SESSION_COOKIE}=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Strict`;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:contrast && npm run test:editorial",
     "test:contrast": "node --test tests/color-contrast.test.mjs",
     "test:editorial": "vitest run",
-    "test:integration": "firebase emulators:exec --project demo-shruggie-web --only firestore,storage \"vitest run --config vitest.integration.config.mts\"",
+    "test:integration": "firebase emulators:exec --project demo-shruggie-web --only auth,firestore,storage \"vitest run --config vitest.integration.config.mts\"",
     "test:all": "npm test && npm run test:integration"
   },
   "dependencies": {

--- a/tests/editorial/assets-and-export.test.ts
+++ b/tests/editorial/assets-and-export.test.ts
@@ -15,7 +15,7 @@ import {
   InMemoryArticleRepository,
   InMemoryAssetStore,
 } from "../../lib/editorial/memory-adapter";
-import { articleFixture } from "./fixtures";
+import { articleFixture, mutationContext } from "./fixtures";
 
 async function pngBytes(): Promise<Buffer> {
   return sharp({
@@ -97,6 +97,7 @@ describe("AssetStore contract", () => {
     await articles.create({
       article,
       idempotencyKey: "create-example-0001",
+      mutation: mutationContext(),
     });
 
     const snapshot = await createEditorialExport(

--- a/tests/editorial/firebase-adapter.integration.test.ts
+++ b/tests/editorial/firebase-adapter.integration.test.ts
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { deleteApp, initializeApp, type App } from "firebase-admin/app";
 import { getFirestore, type Firestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
+import { getAuth } from "firebase-admin/auth";
 
 import { FirebaseAssetStore } from "../../lib/editorial/firebase-asset-store";
 import { FirestoreArticleRepository } from "../../lib/editorial/firestore-article-repository";
@@ -11,7 +12,14 @@ import {
   RevisionConflictError,
   SlugCollisionError,
 } from "../../lib/editorial/errors";
-import { articleFixture, nextRevision } from "./fixtures";
+import {
+  createEditorSessionCookie,
+  EDITOR_SESSION_COOKIE,
+  verifyEditorIdToken,
+  verifyEditorSession,
+  type EditorialSecurityConfig,
+} from "../../lib/editorial/security";
+import { articleFixture, mutationContext, nextRevision } from "./fixtures";
 
 const projectId = "demo-shruggie-web";
 const bucketName = `${projectId}.firebasestorage.app`;
@@ -22,6 +30,9 @@ let db: Firestore;
 beforeAll(() => {
   if (!process.env.FIRESTORE_EMULATOR_HOST) {
     throw new Error("Run this test through npm run test:integration.");
+  }
+  if (!process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+    throw new Error("The Firebase Auth emulator is required.");
   }
   app = initializeApp(
     { projectId, storageBucket: bucketName },
@@ -46,18 +57,78 @@ afterAll(async () => {
 });
 
 describe("Firebase editorial adapters", () => {
+  it("creates, verifies, and revokes an allowlisted staff session", async () => {
+    const auth = getAuth(app);
+    const uid = "editorial-security-test";
+    const email = "editor@shruggie.tech";
+    await auth.createUser({ email, emailVerified: true, uid });
+    try {
+      const customToken = await auth.createCustomToken(uid);
+      const response = await fetch(
+        `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=demo-key`,
+        {
+          body: JSON.stringify({
+            returnSecureToken: true,
+            token: customToken,
+          }),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(response.ok).toBe(true);
+      const tokenResponse = (await response.json()) as { idToken: string };
+      const securityConfig: EditorialSecurityConfig = {
+        adminEmails: new Set(),
+        canonicalOrigin: "http://localhost:3000",
+        editorEmails: new Set([email]),
+      };
+      const principal = await verifyEditorIdToken(
+        tokenResponse.idToken,
+        auth,
+        securityConfig,
+      );
+      expect(principal).toMatchObject({ role: "editor", uid });
+
+      const sessionCookie = await createEditorSessionCookie(
+        tokenResponse.idToken,
+        auth,
+      );
+      await expect(
+        verifyEditorSession(
+          `${EDITOR_SESSION_COOKIE}=${encodeURIComponent(sessionCookie)}`,
+          auth,
+          securityConfig,
+        ),
+      ).resolves.toEqual(principal);
+
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+      await auth.revokeRefreshTokens(uid);
+      await expect(
+        verifyEditorSession(
+          `${EDITOR_SESSION_COOKIE}=${encodeURIComponent(sessionCookie)}`,
+          auth,
+          securityConfig,
+        ),
+      ).rejects.toMatchObject({ code: "INVALID_SESSION", status: 401 });
+    } finally {
+      await auth.deleteUser(uid);
+    }
+  });
+
   it("enforces slug reservations, optimistic revisions, and visibility", async () => {
     const repository = new FirestoreArticleRepository(db);
     const draft = articleFixture();
     await repository.create({
       article: draft,
       idempotencyKey: "firebase-create-0001",
+      mutation: mutationContext("request:firebase-create-0001"),
     });
 
     await expect(
       repository.create({
         article: articleFixture({ id: "article:collision" }),
         idempotencyKey: "firebase-create-0002",
+        mutation: mutationContext("request:firebase-create-0002"),
       }),
     ).rejects.toBeInstanceOf(SlugCollisionError);
     await expect(
@@ -73,18 +144,29 @@ describe("Firebase editorial adapters", () => {
         article: published,
         expectedRevision: 0,
         idempotencyKey: "firebase-update-0001",
+        mutation: mutationContext("request:firebase-update-0001"),
       }),
     ).rejects.toBeInstanceOf(RevisionConflictError);
     await repository.update({
       article: published,
       expectedRevision: 1,
       idempotencyKey: "firebase-update-0002",
+      mutation: mutationContext("request:firebase-update-0002"),
     });
 
     await expect(
       repository.getBySlug(draft.slug, "published"),
     ).resolves.toEqual(published);
     await expect(repository.exportAll()).resolves.toEqual([published]);
+    const audit = await repository.exportAudit();
+    expect(audit).toHaveLength(2);
+    expect(audit.map((event) => event.action).sort()).toEqual([
+      "create",
+      "publish",
+    ]);
+    expect(audit.every((event) => event.actorId === "editor:natalie")).toBe(
+      true,
+    );
   });
 
   it("stores validated image bytes privately and exports their records", async () => {

--- a/tests/editorial/fixtures.ts
+++ b/tests/editorial/fixtures.ts
@@ -2,6 +2,17 @@ import {
   ARTICLE_SCHEMA_VERSION,
   type Article,
 } from "../../lib/editorial/domain";
+import type { EditorialMutationContext } from "../../lib/editorial/audit";
+
+export function mutationContext(
+  requestId = "request:editorial-test-0001",
+): EditorialMutationContext {
+  return {
+    actorId: "editor:natalie",
+    requestId,
+    role: "editor",
+  };
+}
 
 export function articleFixture(overrides: Partial<Article> = {}): Article {
   const base: Article = {

--- a/tests/editorial/repository.test.ts
+++ b/tests/editorial/repository.test.ts
@@ -9,7 +9,7 @@ import {
   SlugCollisionError,
 } from "../../lib/editorial/errors";
 import { InMemoryArticleRepository } from "../../lib/editorial/memory-adapter";
-import { articleFixture, nextRevision } from "./fixtures";
+import { articleFixture, mutationContext, nextRevision } from "./fixtures";
 
 describe("ArticleRepository contract", () => {
   it("reserves slugs and returns actionable collisions", async () => {
@@ -17,12 +17,14 @@ describe("ArticleRepository contract", () => {
     await repository.create({
       article: articleFixture(),
       idempotencyKey: "create-example-0001",
+      mutation: mutationContext("request:create-example-0001"),
     });
 
     await expect(
       repository.create({
         article: articleFixture({ id: "article:other" }),
         idempotencyKey: "create-example-0002",
+        mutation: mutationContext("request:create-example-0002"),
       }),
     ).rejects.toMatchObject<Partial<SlugCollisionError>>({
       code: "SLUG_COLLISION",
@@ -43,6 +45,7 @@ describe("ArticleRepository contract", () => {
         article: published,
         expectedRevision: 0,
         idempotencyKey: "update-example-0001",
+        mutation: mutationContext("request:update-example-0001"),
       }),
     ).rejects.toBeInstanceOf(RevisionConflictError);
     await expect(
@@ -50,6 +53,7 @@ describe("ArticleRepository contract", () => {
         article: published,
         expectedRevision: 1,
         idempotencyKey: "update-example-0002",
+        mutation: mutationContext("request:update-example-0002"),
       }),
     ).rejects.toBeInstanceOf(InvalidStateTransitionError);
   });
@@ -59,15 +63,120 @@ describe("ArticleRepository contract", () => {
     const command = {
       article: articleFixture(),
       idempotencyKey: "create-example-0001",
+      mutation: mutationContext("request:replay-example-0001"),
     };
     await expect(repository.create(command)).resolves.toEqual(command.article);
-    await expect(repository.create(command)).resolves.toEqual(command.article);
+    await expect(
+      repository.create({
+        ...command,
+        mutation: mutationContext("request:retried-example-0002"),
+      }),
+    ).resolves.toEqual(command.article);
     await expect(
       repository.create({
         ...command,
         article: articleFixture({ title: "Different request" }),
       }),
     ).rejects.toBeInstanceOf(EditorialValidationError);
+    await expect(repository.exportAudit()).resolves.toHaveLength(1);
+  });
+
+  it("records attributable lifecycle audit events and rejects impersonation", async () => {
+    const repository = new InMemoryArticleRepository();
+    const draft = articleFixture();
+    await repository.create({
+      article: draft,
+      idempotencyKey: "audit-create-example-0001",
+      mutation: mutationContext("request:audit-create-0001"),
+    });
+    const published = nextRevision(draft, {
+      state: "published",
+      publishedAt: "2026-09-05T13:00:00.000Z",
+    });
+    await repository.update({
+      article: published,
+      expectedRevision: 1,
+      idempotencyKey: "audit-publish-example-0001",
+      mutation: mutationContext("request:audit-publish-0001"),
+    });
+    const unpublished = nextRevision(published, {
+      modifiedAt: "2026-09-05T14:00:00.000Z",
+      publishedAt: null,
+      state: "draft",
+    });
+    await repository.update({
+      article: unpublished,
+      expectedRevision: 2,
+      idempotencyKey: "audit-unpublish-example-0001",
+      mutation: mutationContext("request:audit-unpublish-0001"),
+    });
+    const edited = nextRevision(unpublished, {
+      modifiedAt: "2026-09-05T15:00:00.000Z",
+      title: "An edited example article",
+    });
+    await repository.update({
+      article: edited,
+      expectedRevision: 3,
+      idempotencyKey: "audit-edit-example-0001",
+      mutation: mutationContext("request:audit-edit-0001"),
+    });
+    const archived = nextRevision(edited, {
+      modifiedAt: "2026-09-05T16:00:00.000Z",
+      state: "archived",
+    });
+    await repository.update({
+      article: archived,
+      expectedRevision: 4,
+      idempotencyKey: "audit-archive-example-0001",
+      mutation: mutationContext("request:audit-archive-0001"),
+    });
+    const restored = nextRevision(archived, {
+      modifiedAt: "2026-09-05T17:00:00.000Z",
+      state: "draft",
+    });
+    await repository.update({
+      article: restored,
+      expectedRevision: 5,
+      idempotencyKey: "audit-restore-example-0001",
+      mutation: mutationContext("request:audit-restore-0001"),
+    });
+    const events = await repository.exportAudit();
+    expect(events.map((event) => event.action).sort()).toEqual([
+      "archive",
+      "create",
+      "edit",
+      "publish",
+      "restore",
+      "unpublish",
+    ]);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorId: "editor:natalie",
+          actorRole: "editor",
+          articleId: draft.id,
+        }),
+      ]),
+    );
+
+    await expect(
+      repository.update({
+        article: nextRevision(restored, {
+          modifiedAt: "2026-09-05T18:00:00.000Z",
+        }),
+        expectedRevision: 6,
+        idempotencyKey: "audit-impersonation-0001",
+        mutation: {
+          actorId: "editor:someone-else",
+          requestId: "request:audit-impersonation-0001",
+          role: "admin",
+        },
+      }),
+    ).rejects.toBeInstanceOf(EditorialValidationError);
+    await expect(repository.getById(restored.id, "all")).resolves.toEqual(
+      restored,
+    );
+    await expect(repository.exportAudit()).resolves.toHaveLength(6);
   });
 
   it("keeps drafts out of published queries", async () => {
@@ -92,6 +201,7 @@ describe("ArticleRepository contract", () => {
       repository.create({
         article: articleFixture(),
         idempotencyKey: "too-short",
+        mutation: mutationContext("request:invalid-key-0001"),
       }),
     ).rejects.toBeInstanceOf(EditorialValidationError);
     await expect(

--- a/tests/editorial/security.test.ts
+++ b/tests/editorial/security.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertCanonicalMutationOrigin,
+  authorizeEditorIdentity,
+  clearEditorSessionCookie,
+  EDITOR_SESSION_COOKIE,
+  EditorialSecurityError,
+  loadEditorialSecurityConfig,
+  mutationContextFor,
+  requireEditorialRole,
+  serializeEditorSessionCookie,
+  verifyEditorIdToken,
+  verifyEditorSession,
+  type EditorialAuthVerifier,
+  type EditorialSecurityConfig,
+  type VerifiedFirebaseIdentity,
+} from "../../lib/editorial/security";
+
+const nowSeconds = 1_788_607_200;
+
+function config(): EditorialSecurityConfig {
+  return {
+    adminEmails: new Set(["admin@shruggie.tech"]),
+    canonicalOrigin: "https://shruggie.tech",
+    editorEmails: new Set(["editor@shruggie.tech"]),
+  };
+}
+
+function identity(
+  overrides: Partial<VerifiedFirebaseIdentity> = {},
+): VerifiedFirebaseIdentity {
+  return {
+    auth_time: nowSeconds - 30,
+    email: "editor@shruggie.tech",
+    email_verified: true,
+    uid: "FirebaseUidWithMixedCase",
+    ...overrides,
+  };
+}
+
+function verifier(
+  value: VerifiedFirebaseIdentity = identity(),
+): EditorialAuthVerifier {
+  return {
+    verifyIdToken: vi.fn().mockResolvedValue(value),
+    verifySessionCookie: vi.fn().mockResolvedValue(value),
+  };
+}
+
+describe("editorial security boundary", () => {
+  it("loads explicit editor and administrator allowlists", () => {
+    const loaded = loadEditorialSecurityConfig({
+      CMS_ADMIN_EMAILS: " Admin@Shruggie.Tech ",
+      CMS_EDITOR_EMAILS: "editor@shruggie.tech, second@shruggie.tech",
+      NEXT_PUBLIC_SITE_URL: "https://shruggie.tech/blog",
+    });
+    expect(loaded).toMatchObject({
+      canonicalOrigin: "https://shruggie.tech",
+    });
+    expect([...loaded.adminEmails]).toEqual(["admin@shruggie.tech"]);
+    expect([...loaded.editorEmails]).toEqual([
+      "editor@shruggie.tech",
+      "second@shruggie.tech",
+    ]);
+    expect(() =>
+      loadEditorialSecurityConfig({
+        CMS_EDITOR_EMAILS: "editor@shruggie.tech",
+        NEXT_PUBLIC_SITE_URL: "http://shruggie.tech",
+      }),
+    ).toThrow(/must use HTTPS/);
+  });
+
+  it("authorizes only verified allowlisted identities with bounded roles", () => {
+    const editor = authorizeEditorIdentity(identity(), config());
+    const admin = authorizeEditorIdentity(
+      identity({ email: "admin@shruggie.tech" }),
+      config(),
+    );
+    expect(editor).toMatchObject({ role: "editor" });
+    expect(editor.id).toMatch(/^editor:[a-f0-9]{32}$/);
+    expect(JSON.stringify(editor)).not.toContain("editor@shruggie.tech");
+    expect(admin).toMatchObject({ role: "admin" });
+    expect(() => requireEditorialRole(editor, "admin")).toThrowError(
+      EditorialSecurityError,
+    );
+    expect(() => requireEditorialRole(admin, "admin")).not.toThrow();
+    expect(() =>
+      authorizeEditorIdentity(
+        identity({ email: "outsider@example.com" }),
+        config(),
+      ),
+    ).toThrowError(/not approved/);
+    expect(() =>
+      authorizeEditorIdentity(identity({ email_verified: false }), config()),
+    ).toThrowError(/verified/);
+  });
+
+  it("checks revocation and recent authentication before issuing a session", async () => {
+    const auth = verifier();
+    await expect(
+      verifyEditorIdToken("fresh-token", auth, config(), nowSeconds),
+    ).resolves.toMatchObject({ role: "editor" });
+    expect(auth.verifyIdToken).toHaveBeenCalledWith("fresh-token", true);
+
+    await expect(
+      verifyEditorIdToken(
+        "stale-token",
+        verifier(identity({ auth_time: nowSeconds - 301 })),
+        config(),
+        nowSeconds,
+      ),
+    ).rejects.toMatchObject({ code: "STALE_SIGN_IN", status: 401 });
+
+    const revoked = verifier();
+    vi.mocked(revoked.verifyIdToken).mockRejectedValue({
+      code: "auth/id-token-revoked",
+    });
+    await expect(
+      verifyEditorIdToken("revoked-token", revoked, config(), nowSeconds),
+    ).rejects.toMatchObject({ code: "INVALID_SESSION", status: 401 });
+
+    const outage = verifier();
+    vi.mocked(outage.verifyIdToken).mockRejectedValue({
+      code: "auth/internal-error",
+    });
+    await expect(
+      verifyEditorIdToken("token", outage, config(), nowSeconds),
+    ).rejects.toMatchObject({ code: "AUTH_UNAVAILABLE", status: 503 });
+  });
+
+  it("fails closed for missing, revoked, and unauthorized sessions", async () => {
+    await expect(
+      verifyEditorSession(null, verifier(), config()),
+    ).rejects.toMatchObject({ code: "UNAUTHENTICATED", status: 401 });
+
+    const auth = verifier();
+    await expect(
+      verifyEditorSession(
+        `${EDITOR_SESSION_COOKIE}=signed-cookie`,
+        auth,
+        config(),
+      ),
+    ).resolves.toMatchObject({ role: "editor" });
+    expect(auth.verifySessionCookie).toHaveBeenCalledWith(
+      "signed-cookie",
+      true,
+    );
+
+    const revoked = verifier();
+    vi.mocked(revoked.verifySessionCookie).mockRejectedValue({
+      code: "auth/session-cookie-revoked",
+    });
+    await expect(
+      verifyEditorSession(
+        `${EDITOR_SESSION_COOKIE}=revoked-cookie`,
+        revoked,
+        config(),
+      ),
+    ).rejects.toMatchObject({ code: "INVALID_SESSION", status: 401 });
+  });
+
+  it("rejects missing and cross-origin mutations", () => {
+    expect(() =>
+      assertCanonicalMutationOrigin(null, "https://shruggie.tech"),
+    ).toThrowError(/Origin header/);
+    expect(() =>
+      assertCanonicalMutationOrigin(
+        "https://attacker.example",
+        "https://shruggie.tech",
+      ),
+    ).toThrowError(/Cross-origin/);
+    expect(() =>
+      assertCanonicalMutationOrigin(
+        "https://shruggie.tech/path",
+        "https://shruggie.tech",
+      ),
+    ).not.toThrow();
+  });
+
+  it("creates redacted mutation context and hardened cookies", () => {
+    const principal = authorizeEditorIdentity(identity(), config());
+    expect(mutationContextFor(principal, "request:security-test-0001")).toEqual(
+      {
+        actorId: principal.id,
+        requestId: "request:security-test-0001",
+        role: "editor",
+      },
+    );
+    expect(serializeEditorSessionCookie("signed value", 3600)).toContain(
+      "HttpOnly; Secure; SameSite=Strict",
+    );
+    expect(clearEditorSessionCookie()).toContain("Max-Age=0");
+  });
+});


### PR DESCRIPTION
## Summary

- verify Firebase ID tokens and session cookies with revocation checks
- authorize verified accounts through explicit server-side editor and administrator allowlists
- issue eight-hour HTTP-only Secure same-site session cookies after recent sign-in
- enforce exact canonical origins and strict payloads on every editorial mutation
- protect draft article, private asset, mutation, and administrator-only audit routes
- bind writes to pseudonymous verified actors and reject impersonation
- commit articles, immutable revisions, idempotency records, and redacted audit events transactionally
- document roles, session behavior, outage handling, revocation, and production activation

## Verification

- GitHub Actions Validate: passed
- Firebase Auth session creation, verification, and revocation: passed
- Firebase Firestore and Storage emulator adapter suite: passed
- npm test: 30 passed
- npm run lint: passed
- npx tsc --noEmit: passed
- npm run build: passed
- Vercel preview: passed

## Production configuration

The administrator and editor allowlists are stored as encrypted production variables in the linked Vercel project. Google sign-in will be enabled only after this server boundary reaches production.

Closes #26