### PR TITLE
fix(cms): prevent hanging staff sign-in

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -48,6 +48,34 @@ type AssetSlot = "featuredImage" | "ogImage";
 const inputClass =
   "mt-2 w-full rounded-lg border border-border bg-bg-primary px-3 py-2.5 text-text-primary shadow-sm outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/25 disabled:cursor-not-allowed disabled:opacity-60";
 const labelClass = "block font-medium text-text-primary";
+const DRAFT_RECOVERY_KEY = "shruggie:editorial-draft-recovery";
+
+interface DraftRecovery {
+  draft: Article;
+  persisted: Article | null;
+}
+
+function readDraftRecovery(): DraftRecovery | null {
+  try {
+    const value = JSON.parse(
+      sessionStorage.getItem(DRAFT_RECOVERY_KEY) ?? "null",
+    ) as DraftRecovery | null;
+    if (
+      !value?.draft ||
+      typeof value.draft.id !== "string" ||
+      typeof value.draft.body?.source !== "string"
+    ) {
+      return null;
+    }
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+function clearDraftRecovery(): void {
+  sessionStorage.removeItem(DRAFT_RECOVERY_KEY);
+}
 
 function isSessionError(error: unknown): boolean {
   return (
@@ -87,6 +115,19 @@ export default function EditorialWorkspace() {
   const [dirty, setDirty] = useState(false);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
 
+  const signedIn = useCallback((nextEditor: EditorialEditor) => {
+    const recovery = readDraftRecovery();
+    setEditor(nextEditor);
+    setSessionExpired(false);
+    setSessionState("ready");
+    setListState("idle");
+    if (recovery) {
+      setPersisted(recovery.persisted);
+      setDraft(recovery.draft);
+      setDirty(true);
+    }
+  }, []);
+
   const handleSessionFailure = useCallback((error: unknown) => {
     if (isSessionError(error)) {
       setSessionExpired(true);
@@ -120,8 +161,7 @@ export default function EditorialWorkspace() {
     getEditorialSession()
       .then((nextEditor) => {
         if (!active) return;
-        setEditor(nextEditor);
-        setSessionState("ready");
+        signedIn(nextEditor);
       })
       .catch((error) => {
         if (!active) return;
@@ -130,7 +170,7 @@ export default function EditorialWorkspace() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [signedIn]);
 
   useEffect(() => {
     if (editor && sessionState === "ready" && listState === "idle") {
@@ -138,17 +178,20 @@ export default function EditorialWorkspace() {
     }
   }, [editor, listState, loadWorkspace, sessionState]);
 
-  function signedIn(nextEditor: EditorialEditor) {
-    setEditor(nextEditor);
-    setSessionExpired(false);
-    setSessionState("ready");
-    setListState("idle");
-  }
+  useEffect(() => {
+    if (draft && dirty) {
+      sessionStorage.setItem(
+        DRAFT_RECOVERY_KEY,
+        JSON.stringify({ draft, persisted } satisfies DraftRecovery),
+      );
+    }
+  }, [dirty, draft, persisted]);
 
   async function signOut() {
     try {
       await deleteEditorialSession();
     } finally {
+      clearDraftRecovery();
       setEditor(null);
       setSessionState("idle");
       setArticles([]);
@@ -162,6 +205,7 @@ export default function EditorialWorkspace() {
 
   function beginNewArticle() {
     if (!editor) return;
+    clearDraftRecovery();
     setPersisted(null);
     setDraft(createBlankArticle(editor.id));
     setDirty(false);
@@ -169,6 +213,7 @@ export default function EditorialWorkspace() {
   }
 
   function editArticle(article: Article) {
+    clearDraftRecovery();
     setPersisted(article);
     setDraft(structuredClone(article));
     setDirty(false);
@@ -184,6 +229,7 @@ export default function EditorialWorkspace() {
     setDraft(null);
     setDirty(false);
     setConfirmDiscard(false);
+    clearDraftRecovery();
   }
 
   if (sessionState === "loading") {
@@ -258,6 +304,7 @@ export default function EditorialWorkspace() {
           }}
           onClose={closeEditor}
           onSaved={(saved) => {
+            clearDraftRecovery();
             setPersisted(saved);
             setDraft(structuredClone(saved));
             setDirty(false);

--- a/components/editorial/SignInPanel.tsx
+++ b/components/editorial/SignInPanel.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { LogIn } from "lucide-react";
 
 import {
   createEditorialSession,
   type EditorialEditor,
 } from "@/lib/editorial/client-api";
-import { getFreshGoogleIdToken } from "@/lib/editorial/firebase-browser";
+import {
+  completeGoogleSignIn,
+  startGoogleSignIn,
+} from "@/lib/editorial/firebase-browser";
 import { Button } from "@/components/ui/Button";
 
 interface SignInPanelProps {
@@ -22,21 +25,37 @@ export default function SignInPanel({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    let active = true;
+    completeGoogleSignIn()
+      .then(async (idToken) => {
+        if (!active || !idToken) return;
+        setBusy(true);
+        onSignedIn(await createEditorialSession(idToken));
+      })
+      .catch((caught) => {
+        if (!active) return;
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "Google sign-in could not be completed.",
+        );
+        setBusy(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [onSignedIn]);
+
   async function signIn() {
     setBusy(true);
     setError(null);
     try {
-      const idToken = await getFreshGoogleIdToken();
-      onSignedIn(await createEditorialSession(idToken));
+      await startGoogleSignIn();
     } catch (caught) {
       const message =
         caught instanceof Error ? caught.message : "Sign-in failed.";
-      setError(
-        message.includes("popup-closed")
-          ? "The sign-in window was closed before authentication finished."
-          : message,
-      );
-    } finally {
+      setError(message);
       setBusy(false);
     }
   }
@@ -77,7 +96,7 @@ export default function SignInPanel({
         disabled={busy}
         className="mt-7 w-full sm:w-auto"
       >
-        {busy ? "Opening Google sign-in…" : "Continue with Google"}
+        {busy ? "Redirecting to Google…" : "Continue with Google"}
       </Button>
     </section>
   );

--- a/docs/editorial/authoring-workspace.md
+++ b/docs/editorial/authoring-workspace.md
@@ -7,6 +7,8 @@ contracts from #25 and the server session boundary from #26.
 ## Staff workflow
 
 1. Open `/admin` and sign in with an approved `shruggie.tech` Google account.
+   Authentication uses a same-tab Firebase redirect so browsers that suppress
+   popup windows cannot leave the workspace waiting indefinitely.
 2. Create a draft or open an existing draft from the article list.
 3. Complete the article details and Markdown body. Leaving the title field
    proposes a canonical slug when the slug is still empty.
@@ -25,8 +27,9 @@ preview, rollback, and cache-convergence workflow in #28 is complete.
 ## Failure behavior
 
 - A stale save returns a visible conflict and keeps the local form intact.
-- A session-expiry dialog covers the workspace without unmounting the form;
-  reauthentication resumes the current browser state.
+- Unsaved forms are recoverable from same-tab session storage across the Google
+  redirect. The recovery record is cleared after saving, discarding, or
+  signing out.
 - Article-list and revision-history failures provide bounded retry actions.
 - Dependency failures are described without claiming that a write succeeded.
 - Published and archived records are read-only until #28 supplies the complete

--- a/lib/editorial/firebase-browser.ts
+++ b/lib/editorial/firebase-browser.ts
@@ -3,8 +3,9 @@
 import { getApp, getApps, initializeApp } from "firebase/app";
 import {
   getAuth,
+  getRedirectResult,
   GoogleAuthProvider,
-  signInWithPopup,
+  signInWithRedirect,
   signOut,
 } from "firebase/auth";
 
@@ -29,14 +30,24 @@ function browserAuth() {
   return getAuth(app);
 }
 
-export async function getFreshGoogleIdToken(): Promise<string> {
-  const auth = browserAuth();
+function googleProvider(): GoogleAuthProvider {
   const provider = new GoogleAuthProvider();
   provider.setCustomParameters({
     hd: "shruggie.tech",
     prompt: "select_account",
   });
-  const credential = await signInWithPopup(auth, provider);
+  return provider;
+}
+
+export async function startGoogleSignIn(): Promise<void> {
+  const auth = browserAuth();
+  await signInWithRedirect(auth, googleProvider());
+}
+
+export async function completeGoogleSignIn(): Promise<string | null> {
+  const auth = browserAuth();
+  const credential = await getRedirectResult(auth);
+  if (!credential) return null;
   const idToken = await credential.user.getIdToken(true);
   await signOut(auth);
   return idToken;

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -10,8 +10,14 @@ import EditorialWorkspace from "../../components/editorial/EditorialWorkspace";
 import type { Article } from "../../lib/editorial/domain";
 import { articleFixture, nextRevision } from "./fixtures";
 
+const firebaseBrowserMocks = vi.hoisted(() => ({
+  completeGoogleSignIn: vi.fn(),
+  startGoogleSignIn: vi.fn(),
+}));
+
 vi.mock("../../lib/editorial/firebase-browser", () => ({
-  getFreshGoogleIdToken: vi.fn(),
+  completeGoogleSignIn: firebaseBrowserMocks.completeGoogleSignIn,
+  startGoogleSignIn: firebaseBrowserMocks.startGoogleSignIn,
 }));
 
 function json(body: unknown, status = 200): Response {
@@ -70,6 +76,9 @@ function sessionAndWorkspaceFetch(
 }
 
 beforeEach(() => {
+  sessionStorage.clear();
+  firebaseBrowserMocks.completeGoogleSignIn.mockResolvedValue(null);
+  firebaseBrowserMocks.startGoogleSignIn.mockResolvedValue(undefined);
   Object.defineProperty(globalThis, "fetch", {
     configurable: true,
     value: sessionAndWorkspaceFetch(),
@@ -86,6 +95,31 @@ afterEach(() => {
 });
 
 describe("EditorialWorkspace", () => {
+  it("uses a same-tab Google redirect instead of a popup", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      json(
+        {
+          error: {
+            code: "UNAUTHENTICATED",
+            message: "An editorial session is required.",
+          },
+        },
+        401,
+      ),
+    );
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Continue with Google" }),
+    );
+
+    expect(firebaseBrowserMocks.startGoogleSignIn).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("button", { name: "Redirecting to Google…" }),
+    ).toBeDisabled();
+  });
+
   it("supports the complete keyboard draft-authoring journey", async () => {
     const user = userEvent.setup();
     const fetchMock = sessionAndWorkspaceFetch();
@@ -290,5 +324,25 @@ describe("EditorialWorkspace", () => {
       await screen.findByRole("dialog", { name: "Session expired" }),
     ).toBeInTheDocument();
     expect(title).toHaveValue("Still here after reauthentication");
+  });
+
+  it("recovers an unsaved draft after same-tab authentication navigation", async () => {
+    const user = userEvent.setup();
+    const firstRender = render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: "New article" }),
+    );
+    await user.type(
+      screen.getByLabelText("Title"),
+      "Recovered after Google redirect",
+    );
+
+    await screen.findByText("Unsaved changes");
+    firstRender.unmount();
+    render(<EditorialWorkspace />);
+
+    expect(await screen.findByLabelText("Title")).toHaveValue(
+      "Recovered after Google redirect",
+    );
   });
 });


### PR DESCRIPTION
Fixes the production acceptance blocker in #27. Replaces the popup-only Firebase flow with a same-tab Google redirect, completes the redirect on return, and recovers unsaved drafts from session-scoped storage across reauthentication. Lint, typecheck, 43 tests, accessibility coverage, and the production build pass locally.