### PR TITLE
fix(cms): keep Firebase auth state first-party

### DIFF
--- a/docs/editorial/authoring-workspace.md
+++ b/docs/editorial/authoring-workspace.md
@@ -8,7 +8,9 @@ contracts from #25 and the server session boundary from #26.
 
 1. Open `/admin` and sign in with an approved `shruggie.tech` Google account.
    Authentication uses a same-tab Firebase redirect so browsers that suppress
-   popup windows cannot leave the workspace waiting indefinitely.
+   popup windows cannot leave the workspace waiting indefinitely. Production
+   serves Firebase's auth helper through `/__/auth/*` on `shruggie.tech`, which
+   keeps redirect state first-party in storage-partitioned browsers.
 2. Create a draft or open an existing draft from the article list.
 3. Complete the article details and Markdown body. Leaving the title field
    proposes a canonical slug when the slug is still empty.

--- a/lib/editorial/firebase-browser.ts
+++ b/lib/editorial/firebase-browser.ts
@@ -10,10 +10,14 @@ import {
 } from "firebase/auth";
 
 function browserAuth() {
+  const configuredAuthDomain = process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN;
   const config = {
     apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
     appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    authDomain: resolveFirebaseAuthDomain(
+      window.location.hostname,
+      configuredAuthDomain,
+    ),
     messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
     projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
     storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
@@ -28,6 +32,13 @@ function browserAuth() {
   }
   const app = getApps().length ? getApp() : initializeApp(config);
   return getAuth(app);
+}
+
+export function resolveFirebaseAuthDomain(
+  hostname: string,
+  configuredAuthDomain: string | undefined,
+): string | undefined {
+  return hostname === "shruggie.tech" ? "shruggie.tech" : configuredAuthDomain;
 }
 
 function googleProvider(): GoogleAuthProvider {

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,12 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizeCss: true,
   },
+  rewrites: async () => [
+    {
+      source: "/__/auth/:path*",
+      destination: "https://shruggie-web.firebaseapp.com/__/auth/:path*",
+    },
+  ],
   headers: async () => [
     {
       source: "/fonts/(.*)",

--- a/tests/editorial/firebase-browser.test.ts
+++ b/tests/editorial/firebase-browser.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveFirebaseAuthDomain } from "../../lib/editorial/firebase-browser";
+
+describe("Firebase browser auth domain", () => {
+  it("keeps production redirect state on the first-party site domain", () => {
+    expect(
+      resolveFirebaseAuthDomain(
+        "shruggie.tech",
+        "shruggie-web.firebaseapp.com",
+      ),
+    ).toBe("shruggie.tech");
+  });
+
+  it("uses the configured Firebase handler outside production", () => {
+    expect(
+      resolveFirebaseAuthDomain(
+        "localhost",
+        "shruggie-web.firebaseapp.com",
+      ),
+    ).toBe("shruggie-web.firebaseapp.com");
+  });
+});


### PR DESCRIPTION
Completes the production authentication fix for #27. Production now uses shruggie.tech as Firebase authDomain and proxies the Firebase auth helper through the same site origin, avoiding third-party storage partitioning. Local and non-production environments retain the configured Firebase domain. Lint, typecheck, 45 tests, and the production build pass. Deployment requires registering https://shruggie.tech/__/auth/handler on the existing Google OAuth web client before merge.