### PR TITLE
fix(cms): clarify pre-authorized blog access

### DIFF
--- a/components/editorial/SignInPanel.tsx
+++ b/components/editorial/SignInPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { LogIn } from "lucide-react";
+import Link from "next/link";
 
 import {
   createEditorialSession,
@@ -78,9 +79,20 @@ export default function SignInPanel({
         {expired ? "Your session expired" : "Write for ShruggieTech"}
       </h1>
       <p className="text-body-md text-text-secondary mt-3">
-        {expired
-          ? "Sign in again to continue. Your unsaved changes are still here."
-          : "Use an approved shruggie.tech Google account. Public registration is not available."}
+        {expired ? (
+          "Sign in again to continue. Your unsaved changes are still here."
+        ) : (
+          <>
+            This workspace is for pre-authorized use only. Interested in
+            publishing to our blog?{" "}
+            <Link
+              href="/contact"
+              className="text-accent underline decoration-current/40 underline-offset-4 hover:decoration-current"
+            >
+              Contact us.
+            </Link>
+          </>
+        )}
       </p>
       {error && (
         <div

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -110,8 +110,16 @@ describe("EditorialWorkspace", () => {
     const user = userEvent.setup();
     render(<EditorialWorkspace />);
 
+    expect(
+      await screen.findByText(/This workspace is for pre-authorized use only/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Contact us." })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
+
     await user.click(
-      await screen.findByRole("button", { name: "Continue with Google" }),
+      screen.getByRole("button", { name: "Continue with Google" }),
     );
 
     expect(firebaseBrowserMocks.startGoogleSignIn).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary
- clarify that the staff workspace is for pre-authorized use only
- direct prospective blog contributors to the contact page
- cover the message and contact link in the editorial workspace test

## Verification
- focused ESLint
- TypeScript type check
- editorial workspace test: 8 passed
- Prettier check

Related to #27