### PR TITLE
fix(cms): remove internal roadmap copy

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -664,8 +664,6 @@ function ArticleEditor({
           className="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4"
         >
           This {draft.state} article is read-only in the draft workspace.
-          Publishing, unpublishing, and restoring lifecycle states arrive in
-          #28.
         </div>
       )}
       {conflict && (
@@ -867,7 +865,7 @@ function ArticleEditor({
               Publish
             </Button>
             <p id="publish-note" className="text-body-xs text-text-secondary">
-              Publishing is a separate reviewed action delivered in #28.
+              Publishing requires review.
             </p>
           </div>
         </form>

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -171,6 +171,8 @@ describe("EditorialWorkspace", () => {
     );
     expect(post).toBeTruthy();
     expect(screen.getByRole("button", { name: "Publish" })).toBeDisabled();
+    expect(screen.getByText("Publishing requires review.")).toBeInTheDocument();
+    expect(screen.queryByText(/#28/)).not.toBeInTheDocument();
 
     const accessibility = await axe.run(container, {
       rules: { "color-contrast": { enabled: false } },


### PR DESCRIPTION
## Summary
- remove GitHub issue and delivery jargon from the authoring interface
- replace the publish note with plain user-facing guidance
- keep read-only messaging limited to the behavior users need to understand
- prevent issue-number copy from returning in the workspace test

## Verification
- focused ESLint
- TypeScript type check
- editorial workspace test: 8 passed
- Prettier check

Related to #27 and #28