### PR TITLE
fix(cms): simplify empty article state

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -395,13 +395,6 @@ function ArticleDashboard({
       {articles.length === 0 ? (
         <Card hover={false} className="border-dashed text-center">
           <h3 className="font-display text-xl font-bold">No articles yet</h3>
-          <p className="text-text-secondary mx-auto mt-2 max-w-md">
-            Create the first draft. Nothing becomes public until a separate
-            publish step is completed.
-          </p>
-          <Button type="button" onClick={onCreate} className="mt-6">
-            Create a draft
-          </Button>
         </Card>
       ) : (
         <ul className="grid gap-4" aria-label="Editorial articles">

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -137,6 +137,12 @@ describe("EditorialWorkspace", () => {
     const newArticle = await screen.findByRole("button", {
       name: "New article",
     });
+    expect(
+      screen.getByRole("heading", { name: "No articles yet" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Create a draft" }),
+    ).not.toBeInTheDocument();
     newArticle.focus();
     await user.keyboard("{Enter}");
 


### PR DESCRIPTION
## Summary
- reduce the empty articles state to only its heading
- remove the redundant explanation and duplicate create action
- retain the primary New article button
- cover the simplified state in the workspace test

## Verification
- focused ESLint
- TypeScript type check
- editorial workspace test: 8 passed
- Prettier check

Related to #27