### PR TITLE
fix(cms): serialize Firestore expiry across clients

### DIFF
--- a/lib/editorial/firestore-article-repository.ts
+++ b/lib/editorial/firestore-article-repository.ts
@@ -8,7 +8,6 @@ import type {
   Firestore,
   Transaction,
 } from "firebase-admin/firestore";
-import { Timestamp } from "firebase-admin/firestore";
 
 import {
   createAuditEvent,
@@ -47,7 +46,7 @@ const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
 interface IdempotencyRecord {
   articleId: string;
-  expiresAt: Timestamp;
+  expiresAt: Date;
   fingerprint: string;
   revisionNumber: number;
 }
@@ -384,7 +383,9 @@ export class FirestoreArticleRepository implements ArticleRepository {
       articleId: article.id,
       revisionNumber: article.revision.number,
       fingerprint: commandFingerprint,
-      expiresAt: Timestamp.fromMillis(Date.now() + IDEMPOTENCY_TTL_MS),
+      // Native dates serialize across both Firestore client versions used by
+      // Firebase Admin locally and the direct Google Cloud client on Vercel.
+      expiresAt: new Date(Date.now() + IDEMPOTENCY_TTL_MS),
     } satisfies IdempotencyRecord);
   }
 }

--- a/tests/editorial/firebase-adapter.integration.test.ts
+++ b/tests/editorial/firebase-adapter.integration.test.ts
@@ -1,6 +1,7 @@
 import sharp from "sharp";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
+import { Firestore as DirectFirestore } from "@google-cloud/firestore";
 import { deleteApp, initializeApp, type App } from "firebase-admin/app";
 import { getFirestore, type Firestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
@@ -26,6 +27,7 @@ const bucketName = `${projectId}.firebasestorage.app`;
 
 let app: App;
 let db: Firestore;
+let directDb: DirectFirestore;
 
 beforeAll(() => {
   if (!process.env.FIRESTORE_EMULATOR_HOST) {
@@ -39,6 +41,7 @@ beforeAll(() => {
     "editorial-test",
   );
   db = getFirestore(app);
+  directDb = new DirectFirestore({ projectId });
 });
 
 afterEach(async () => {
@@ -53,6 +56,7 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
+  await directDb.terminate();
   await deleteApp(app);
 });
 
@@ -171,6 +175,28 @@ describe("Firebase editorial adapters", () => {
     expect(audit.every((event) => event.actorId === "editor:natalie")).toBe(
       true,
     );
+  });
+
+  it("creates idempotency records through the direct Vercel Firestore client", async () => {
+    const repository = new FirestoreArticleRepository(directDb);
+    const draft = articleFixture({
+      id: "article:direct-client",
+      slug: "direct-client",
+    });
+
+    await expect(
+      repository.create({
+        article: draft,
+        idempotencyKey: "firebase-direct-create-0001",
+        mutation: mutationContext("request:firebase-direct-create-0001"),
+      }),
+    ).resolves.toEqual(draft);
+
+    const record = await directDb
+      .collection("idempotencyKeys")
+      .doc("firebase-direct-create-0001")
+      .get();
+    expect(record.get("expiresAt")?.toDate()).toBeInstanceOf(Date);
   });
 
   it("stores validated image bytes privately and exports their records", async () => {


### PR DESCRIPTION
## Summary
- fix the first production draft write failure caused by passing a Firebase Admin v8 Timestamp into the direct Firestore v9 client used on Vercel
- serialize the idempotency expiry as a native Date supported by both clients
- add emulator coverage for article creation through the direct production-style Firestore client

## Verification
- ESLint
- TypeScript type check
- unit/UI suite: 8 files, 45 tests passed
- direct Firestore v9 validation reproduces rejection of the cross-package Timestamp and accepts the native Date
- local Firebase emulator startup was blocked by this Windows host failing to establish Java's loopback selector; CI will run the emulator regression test

Fixes the remaining production-save gate in #27