### PR TITLE
chore(cms): log retryable storage failures

### DIFF
--- a/lib/editorial/http.ts
+++ b/lib/editorial/http.ts
@@ -72,6 +72,13 @@ export function editorialErrorResponse(error: unknown): NextResponse {
     );
   }
   if (error instanceof EditorialError) {
+    if (error.retryable) {
+      console.error("Retryable editorial route error", {
+        cause: error.cause,
+        code: error.code,
+        details: error.details,
+      });
+    }
     const status =
       error.code === "CONTENT_TIMEOUT"
         ? 504


### PR DESCRIPTION
## Summary
- log retryable editorial storage failures server-side with their error code, operation details, and underlying cause
- keep the existing sanitized client response unchanged

## Validation
- npx prettier --check lib/editorial/http.ts
- npx eslint lib/editorial/http.ts
- npx tsc --noEmit
- npm test

Supports #27.