### PR TITLE
fix(cms): externalize Firestore server package

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  // Firestore's REST transport relies on protobuf Long constructor metadata.
+  // Keep the package out of Next's minified server bundle so integer fields
+  // serialize correctly in Vercel functions.
+  serverExternalPackages: ["@google-cloud/firestore"],
   images: {
     formats: ["image/avif", "image/webp"],
     remotePatterns: [


### PR DESCRIPTION
## Summary
- keep @google-cloud/firestore out of Next.js's minified Vercel server bundle
- preserve protobuf Long constructor metadata required by Firestore's REST transport
- fix production draft writes failing with toProto3JSON integer serialization errors

## Validation
- npx prettier --check next.config.ts
- npx eslint next.config.ts
- npx tsc --noEmit
- npm test (45 editorial + 4 contrast tests)
- npm run build
- verified the Firestore protobuf serializer is absent from generated server chunks and the dependency is emitted as an external require

Fixes the remaining production-save blocker for #27.