### PR TITLE
fix(cms): contain article editor scrolling

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -805,6 +805,7 @@ function ArticleEditor({
             <textarea
               id="body.source"
               aria-label="Article body in Markdown"
+              data-lenis-prevent
               rows={22}
               value={draft.body.source}
               disabled={readOnly}
@@ -813,7 +814,7 @@ function ArticleEditor({
                 errors["body.source"] ? "body.source-error" : "body-hint"
               }
               onChange={(event) => field("body.source", event.target.value)}
-              className={`${inputClass} text-body-sm resize-y font-mono leading-6`}
+              className={`${inputClass} text-body-sm resize-y overscroll-contain font-mono leading-6`}
             />
             {errors["body.source"] && (
               <p

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -186,6 +186,21 @@ describe("EditorialWorkspace", () => {
     expect(accessibility.violations).toEqual([]);
   });
 
+  it("keeps article-body scrolling inside the editor", async () => {
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: "New article" }),
+    );
+
+    const articleBody = screen.getByLabelText("Article body in Markdown");
+    expect(articleBody).toHaveAttribute("data-lenis-prevent");
+    expect(articleBody).toHaveClass("overscroll-contain");
+    expect(screen.getByLabelText("Excerpt")).not.toHaveAttribute(
+      "data-lenis-prevent",
+    );
+  });
+
   it("identifies invalid fields and preserves unsaved work", async () => {
     const user = userEvent.setup();
     render(<EditorialWorkspace />);


### PR DESCRIPTION
## Summary
- let the Markdown article textarea receive native wheel and trackpad scrolling instead of Lenis moving the page
- contain overscroll at the textarea boundaries
- add regression coverage scoped to the article body while leaving other fields unchanged

## Validation
- npx prettier --check components/editorial/EditorialWorkspace.tsx tests/editorial/workspace.test.tsx
- npx eslint components/editorial/EditorialWorkspace.tsx tests/editorial/workspace.test.tsx
- npx tsc --noEmit
- npm test (46 editorial + 4 contrast tests)

Closes #57.