### PR TITLE
fix(cms): stop editor wheel scroll chaining

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -470,10 +470,39 @@ function ArticleEditor({
   );
   const [selectedRevision, setSelectedRevision] = useState<number | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
   const readOnly = draft.state !== "draft";
 
   useEffect(() => {
     titleRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const textarea = bodyRef.current;
+    if (!textarea) return;
+
+    const containWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0) return;
+      const multiplier =
+        event.deltaMode === 1
+          ? 16
+          : event.deltaMode === 2
+            ? textarea.clientHeight
+            : 1;
+      const maximum = Math.max(
+        0,
+        textarea.scrollHeight - textarea.clientHeight,
+      );
+      textarea.scrollTop = Math.min(
+        maximum,
+        Math.max(0, textarea.scrollTop + event.deltaY * multiplier),
+      );
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    textarea.addEventListener("wheel", containWheel, { passive: false });
+    return () => textarea.removeEventListener("wheel", containWheel);
   }, []);
 
   const loadRevisions = useCallback(async () => {
@@ -803,6 +832,7 @@ function ArticleEditor({
               are rejected.
             </p>
             <textarea
+              ref={bodyRef}
               id="body.source"
               aria-label="Article body in Markdown"
               data-lenis-prevent

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -199,6 +199,35 @@ describe("EditorialWorkspace", () => {
     expect(screen.getByLabelText("Excerpt")).not.toHaveAttribute(
       "data-lenis-prevent",
     );
+
+    Object.defineProperties(articleBody, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 1_000 },
+    });
+    const pageWheel = vi.fn();
+    document.addEventListener("wheel", pageWheel);
+
+    const scrollInside = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 120,
+    });
+    articleBody.dispatchEvent(scrollInside);
+    expect(articleBody.scrollTop).toBe(120);
+    expect(scrollInside.defaultPrevented).toBe(true);
+    expect(pageWheel).not.toHaveBeenCalled();
+
+    articleBody.scrollTop = 800;
+    articleBody.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        deltaY: 120,
+      }),
+    );
+    expect(articleBody.scrollTop).toBe(800);
+    expect(pageWheel).not.toHaveBeenCalled();
+    document.removeEventListener("wheel", pageWheel);
   });
 
   it("identifies invalid fields and preserves unsaved work", async () => {


### PR DESCRIPTION
## Summary
- consume vertical wheel and trackpad input directly in the Markdown textarea with a non-passive listener
- clamp textarea scrolling at both boundaries and stop the event before Lenis or the page can receive it
- cover normal nested scrolling, default prevention, propagation blocking, and bottom-boundary behavior

## Production finding
PR #58 correctly routed normal scrolling into the textarea, but live verification found that Chrome still chained an additional wheel gesture to the page after the textarea reached its bottom. This follow-up closes that gap.

## Validation
- npx prettier --check components/editorial/EditorialWorkspace.tsx tests/editorial/workspace.test.tsx
- npx eslint components/editorial/EditorialWorkspace.tsx tests/editorial/workspace.test.tsx
- npx tsc --noEmit
- npx vitest run tests/editorial/workspace.test.tsx (9 passed)
- npm test (46 editorial + 4 contrast tests)
- npm run build

Closes #57.