### PR TITLE
feat(cms): add authenticated draft preview

### DIFF
--- a/app/api/admin/preview/exit/route.ts
+++ b/app/api/admin/preview/exit/route.ts
@@ -1,0 +1,22 @@
+import { draftMode } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { editorialErrorResponse, requireEditor } from "@/lib/editorial/http";
+import { loadEditorialSecurityConfig } from "@/lib/editorial/security";
+
+export async function GET(request: Request) {
+  try {
+    await requireEditor(request);
+
+    const mode = await draftMode();
+    mode.disable();
+
+    const { canonicalOrigin } = loadEditorialSecurityConfig();
+    const response = NextResponse.redirect(new URL("/admin", canonicalOrigin));
+    response.headers.set("Cache-Control", "private, no-store, max-age=0");
+    response.headers.set("Vary", "Cookie");
+    return response;
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}

--- a/app/api/admin/preview/route.ts
+++ b/app/api/admin/preview/route.ts
@@ -1,0 +1,36 @@
+import { draftMode } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { articleSlugSchema } from "@/lib/editorial/domain";
+import { ArticleNotFoundError } from "@/lib/editorial/errors";
+import { createFirebaseEditorialBackend } from "@/lib/editorial/firebase-admin";
+import { editorialErrorResponse, requireEditor } from "@/lib/editorial/http";
+import { loadEditorialSecurityConfig } from "@/lib/editorial/security";
+
+export async function GET(request: Request) {
+  try {
+    await requireEditor(request);
+
+    const slug = articleSlugSchema.parse(
+      new URL(request.url).searchParams.get("slug"),
+    );
+    const article = await createFirebaseEditorialBackend().articles.getBySlug(
+      slug,
+      "all",
+    );
+    if (!article) throw new ArticleNotFoundError(slug);
+
+    const mode = await draftMode();
+    mode.enable();
+
+    const { canonicalOrigin } = loadEditorialSecurityConfig();
+    const response = NextResponse.redirect(
+      new URL(`/blog/${article.slug}?preview=1`, canonicalOrigin),
+    );
+    response.headers.set("Cache-Control", "private, no-store, max-age=0");
+    response.headers.set("Vary", "Cookie");
+    return response;
+  } catch (error) {
+    return editorialErrorResponse(error);
+  }
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -10,13 +10,20 @@
  */
 
 import type { Metadata } from "next";
+import { draftMode, headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import Image from "next/image";
 import rehypeShiki from "@shikijs/rehype";
+import { cache } from "react";
 
 import { SITE_URL, getOgImageUrl } from "@/lib/constants";
-import { getAllPostsMeta, getPostBySlug } from "@/lib/blog";
+import {
+  getAllPostsMeta,
+  getPostBySlug,
+  getPreviewPostBySlug,
+} from "@/lib/blog";
+import { requireEditor } from "@/lib/editorial/http";
 import { extractHeadings } from "@/lib/utils";
 import { generateBlogPostSchema } from "@/lib/schema";
 import { mdxComponents } from "@/components/blog/MDXComponents";
@@ -30,6 +37,29 @@ interface BlogPostPageProps {
   params: Promise<{ slug: string }>;
 }
 
+const isAuthorizedDraftPreview = cache(async () => {
+  const mode = await draftMode();
+  if (!mode.isEnabled) return false;
+
+  try {
+    const requestHeaders = new Headers(await headers());
+    await requireEditor(new Request(SITE_URL, { headers: requestHeaders }));
+    return true;
+  } catch {
+    return false;
+  }
+});
+
+async function getPostForRequest(slug: string) {
+  const preview = await isAuthorizedDraftPreview();
+  return {
+    post: preview
+      ? await getPreviewPostBySlug(slug)
+      : await getPostBySlug(slug),
+    preview,
+  };
+}
+
 export async function generateStaticParams() {
   const posts = await getAllPostsMeta();
   return posts.map((post) => ({ slug: post.slug }));
@@ -41,7 +71,8 @@ export async function generateMetadata({
   const resolvedParams = await params;
 
   try {
-    const { meta } = await getPostBySlug(resolvedParams.slug);
+    const { post, preview } = await getPostForRequest(resolvedParams.slug);
+    const { meta } = post;
 
     // Priority chain: ogImage → featuredImage → dynamic /api/og card
     const ogImageUrl = meta.ogImage
@@ -55,6 +86,9 @@ export async function generateMetadata({
     return {
       title: meta.title,
       description: meta.excerpt,
+      robots: preview
+        ? { index: false, follow: false, noarchive: true }
+        : undefined,
       alternates: {
         canonical: `${SITE_URL}/blog/${meta.slug}`,
       },
@@ -92,8 +126,11 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const resolvedParams = await params;
 
   let post;
+  let preview = false;
   try {
-    post = await getPostBySlug(resolvedParams.slug);
+    const result = await getPostForRequest(resolvedParams.slug);
+    post = result.post;
+    preview = result.preview;
   } catch {
     notFound();
   }
@@ -101,7 +138,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { meta, content } = post;
 
   // In production, don't render unpublished posts
-  if (process.env.NODE_ENV === "production" && !meta.published) {
+  if (process.env.NODE_ENV === "production" && !meta.published && !preview) {
     notFound();
   }
 
@@ -109,7 +146,22 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
   return (
     <>
-      <JsonLd data={generateBlogPostSchema(meta)} />
+      {!preview && <JsonLd data={generateBlogPostSchema(meta)} />}
+      {preview && (
+        <div className="border-accent/30 bg-accent/10 border-b">
+          <div className="mx-auto flex max-w-[var(--max-width-content)] flex-wrap items-center justify-between gap-3 px-[var(--padding-x)] py-3">
+            <p className="text-body-sm font-medium">
+              Draft preview — this saved revision has not been published.
+            </p>
+            <a
+              href="/api/admin/preview/exit"
+              className="focus-visible:outline-focus border-border hover:border-accent hover:text-accent rounded-lg border px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2"
+            >
+              Exit preview
+            </a>
+          </div>
+        </div>
+      )}
       <article className="py-20">
         {/* Header — always centered */}
         <div className="mx-auto max-w-[900px] px-[var(--padding-x)]">

--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeft,
   Clock3,
   FilePlus2,
+  Eye,
   ImagePlus,
   LoaderCircle,
   LogOut,
@@ -883,13 +884,31 @@ function ArticleEditor({
             <Button
               type="button"
               variant="secondary"
-              disabled
-              aria-describedby="publish-note"
+              disabled={!persisted || dirty}
+              aria-describedby="preview-note"
+              onClick={() => {
+                if (!persisted || dirty) return;
+                window.open(
+                  `/api/admin/preview?slug=${encodeURIComponent(persisted.slug)}`,
+                  "_blank",
+                  "noopener,noreferrer",
+                );
+              }}
             >
+              <Eye aria-hidden="true" className="mr-2" size={18} /> Preview
+            </Button>
+            <Button type="button" variant="secondary" disabled>
               Publish
             </Button>
-            <p id="publish-note" className="text-body-xs text-text-secondary">
-              Publishing requires review.
+            <p
+              id="preview-note"
+              className="text-body-xs text-text-secondary sm:ml-auto"
+            >
+              {!persisted
+                ? "Save the draft to preview."
+                : dirty
+                  ? "Save changes to refresh the preview."
+                  : "Preview opens the saved draft without publishing."}
             </p>
           </div>
         </form>

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -12,6 +12,7 @@ import readingTime from "reading-time";
 
 import type { Article } from "./editorial/domain";
 import { ArticleNotFoundError } from "./editorial/errors";
+import { createFirebaseEditorialBackend } from "./editorial/firebase-admin";
 import { MdxArticleReader } from "./editorial/mdx-article-reader";
 
 const articleReader = new MdxArticleReader();
@@ -60,6 +61,22 @@ export async function getPostBySlug(slug: string): Promise<{
   const visibility =
     process.env.NODE_ENV === "development" ? "all" : "published";
   const article = await articleReader.getBySlug(slug, visibility);
+  if (!article) throw new ArticleNotFoundError(slug);
+  return { meta: toPostMeta(article), content: article.body.source };
+}
+
+/**
+ * Read the saved editorial copy for an authorized Draft Mode request.
+ * Public blog reads remain repository-backed until the publishing cutover.
+ */
+export async function getPreviewPostBySlug(slug: string): Promise<{
+  content: string;
+  meta: PostMeta;
+}> {
+  const article = await createFirebaseEditorialBackend().articles.getBySlug(
+    slug,
+    "all",
+  );
   if (!article) throw new ArticleNotFoundError(slug);
   return { meta: toPostMeta(article), content: article.body.source };
 }

--- a/tests/editorial/preview-route.test.ts
+++ b/tests/editorial/preview-route.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  disable: vi.fn(),
+  enable: vi.fn(),
+  errorResponse: vi.fn((error: unknown) =>
+    Response.json(
+      { error: error instanceof Error ? error.message : "unknown" },
+      { status: 400 },
+    ),
+  ),
+  getBySlug: vi.fn(),
+  requireEditor: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  draftMode: vi.fn(async () => ({
+    disable: mocks.disable,
+    enable: mocks.enable,
+    isEnabled: false,
+  })),
+}));
+
+vi.mock("@/lib/editorial/firebase-admin", () => ({
+  createFirebaseEditorialBackend: () => ({
+    articles: { getBySlug: mocks.getBySlug },
+  }),
+}));
+
+vi.mock("@/lib/editorial/http", () => ({
+  editorialErrorResponse: mocks.errorResponse,
+  requireEditor: mocks.requireEditor,
+}));
+
+vi.mock("@/lib/editorial/security", () => ({
+  loadEditorialSecurityConfig: () => ({
+    canonicalOrigin: "https://shruggie.tech",
+  }),
+}));
+
+import { GET as enterPreview } from "../../app/api/admin/preview/route";
+import { GET as exitPreview } from "../../app/api/admin/preview/exit/route";
+import { articleFixture } from "./fixtures";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireEditor.mockResolvedValue({
+    id: "editor:natalie",
+    role: "admin",
+    uid: "firebase-user",
+  });
+  mocks.getBySlug.mockResolvedValue(articleFixture());
+});
+
+describe("editorial draft preview routes", () => {
+  it("authenticates, verifies the saved article, and enables Draft Mode", async () => {
+    const request = new Request(
+      "https://shruggie.tech/api/admin/preview?slug=example-article",
+      { headers: { cookie: "__Host-shruggie_editor=session" } },
+    );
+
+    const response = await enterPreview(request);
+
+    expect(mocks.requireEditor).toHaveBeenCalledWith(request);
+    expect(mocks.getBySlug).toHaveBeenCalledWith("example-article", "all");
+    expect(mocks.enable).toHaveBeenCalledOnce();
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://shruggie.tech/blog/example-article?preview=1",
+    );
+    expect(response.headers.get("cache-control")).toContain("no-store");
+  });
+
+  it("does not enable Draft Mode when authentication fails", async () => {
+    mocks.requireEditor.mockRejectedValueOnce(new Error("Unauthorized"));
+
+    const response = await enterPreview(
+      new Request(
+        "https://shruggie.tech/api/admin/preview?slug=example-article",
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.getBySlug).not.toHaveBeenCalled();
+    expect(mocks.enable).not.toHaveBeenCalled();
+  });
+
+  it("does not enable Draft Mode for an unknown article", async () => {
+    mocks.getBySlug.mockResolvedValueOnce(null);
+
+    const response = await enterPreview(
+      new Request(
+        "https://shruggie.tech/api/admin/preview?slug=missing-article",
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.enable).not.toHaveBeenCalled();
+  });
+
+  it("authenticates before disabling Draft Mode and returning to admin", async () => {
+    const request = new Request(
+      "https://shruggie.tech/api/admin/preview/exit",
+      { headers: { cookie: "__Host-shruggie_editor=session" } },
+    );
+
+    const response = await exitPreview(request);
+
+    expect(mocks.requireEditor).toHaveBeenCalledWith(request);
+    expect(mocks.disable).toHaveBeenCalledOnce();
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://shruggie.tech/admin",
+    );
+  });
+});

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -164,6 +164,10 @@ describe("EditorialWorkspace", () => {
       "## A useful heading{Enter}{Enter}A safe article body.",
     );
 
+    const preview = screen.getByRole("button", { name: "Preview" });
+    expect(preview).toBeDisabled();
+    expect(screen.getByText("Save the draft to preview.")).toBeInTheDocument();
+
     const save = screen.getByRole("button", { name: "Save draft" });
     save.focus();
     await user.keyboard("{Enter}");
@@ -176,8 +180,18 @@ describe("EditorialWorkspace", () => {
         String(input) === "/api/admin/articles" && init?.method === "POST",
     );
     expect(post).toBeTruthy();
+    expect(preview).toBeEnabled();
+    expect(
+      screen.getByText("Preview opens the saved draft without publishing."),
+    ).toBeInTheDocument();
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    await user.click(preview);
+    expect(open).toHaveBeenCalledWith(
+      "/api/admin/preview?slug=a-keyboard-authored-article",
+      "_blank",
+      "noopener,noreferrer",
+    );
     expect(screen.getByRole("button", { name: "Publish" })).toBeDisabled();
-    expect(screen.getByText("Publishing requires review.")).toBeInTheDocument();
     expect(screen.queryByText(/#28/)).not.toBeInTheDocument();
 
     const accessibility = await axe.run(container, {


### PR DESCRIPTION
Implements the draft-preview slice of #28.

- adds protected Draft Mode entry and exit routes
- reads the latest saved Firestore draft only for an active authorized editorial session
- renders previews through the real blog article template with a clear draft banner
- prevents preview indexing and omits published structured data
- adds a Preview action that is enabled only for a clean saved revision
- leaves Publish disabled for the remaining #28 work

Validation:
- npm run lint
- npm test (54 tests passing)
- npm run build

#28 remains open for publishing, rollback, cache convergence, and the remaining acceptance criteria.