### PR TITLE
fix(cms): keep preview metadata and body consistent

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -50,7 +50,7 @@ const isAuthorizedDraftPreview = cache(async () => {
   }
 });
 
-async function getPostForRequest(slug: string) {
+const getPostForRequest = cache(async (slug: string) => {
   const preview = await isAuthorizedDraftPreview();
   return {
     post: preview
@@ -58,7 +58,7 @@ async function getPostForRequest(slug: string) {
       : await getPostBySlug(slug),
     preview,
   };
-}
+});
 
 export async function generateStaticParams() {
   const posts = await getAllPostsMeta();


### PR DESCRIPTION
Follow-up to #60 and part of #28.

Live production verification showed that the first cold preview request could complete the page body and metadata reads independently, briefly leaving the document title at the not-found fallback. Memoizing the request-level article loader makes metadata and the page share one authorized Firestore read.

Validation:
- npm run lint
- npm test (54 tests passing)
- npm run build