### PR TITLE
fix(cms): keep draft preview notice below navigation

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -148,7 +148,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     <>
       {!preview && <JsonLd data={generateBlogPostSchema(meta)} />}
       {preview && (
-        <div className="border-accent/30 bg-accent/10 border-b">
+        <div className="border-accent/30 bg-accent/10 border-b pt-16">
           <div className="mx-auto flex max-w-[var(--max-width-content)] flex-wrap items-center justify-between gap-3 px-[var(--padding-x)] py-3">
             <p className="text-body-sm font-medium">
               Draft preview — this saved revision has not been published.


### PR DESCRIPTION
Follow-up to #60 and part of #28.

The preview-only notice started at the top of the document while the site header is fixed at 64px, causing the notice copy to overlap the navigation. This adds the matching preview-only top offset so the notice begins immediately below the header without changing normal blog pages.

Validation:
- Prettier
- npm run lint
- npm test (54 tests passing)
- npm run build
- production viewport reproduction captured before the fix