### PR TITLE
fix(cms): isolate draft preview routing

### DIFF
--- a/app/api/admin/preview/exit/route.ts
+++ b/app/api/admin/preview/exit/route.ts
@@ -2,6 +2,7 @@ import { draftMode } from "next/headers";
 import { NextResponse } from "next/server";
 
 import { editorialErrorResponse, requireEditor } from "@/lib/editorial/http";
+import { EDITOR_PREVIEW_COOKIE } from "@/lib/editorial/preview-session";
 import { loadEditorialSecurityConfig } from "@/lib/editorial/security";
 
 export async function GET(request: Request) {
@@ -13,6 +14,13 @@ export async function GET(request: Request) {
 
     const { canonicalOrigin } = loadEditorialSecurityConfig();
     const response = NextResponse.redirect(new URL("/admin", canonicalOrigin));
+    response.cookies.set(EDITOR_PREVIEW_COOKIE, "", {
+      httpOnly: true,
+      maxAge: 0,
+      path: "/",
+      sameSite: "strict",
+      secure: true,
+    });
     response.headers.set("Cache-Control", "private, no-store, max-age=0");
     response.headers.set("Vary", "Cookie");
     return response;

--- a/app/api/admin/preview/route.ts
+++ b/app/api/admin/preview/route.ts
@@ -5,6 +5,10 @@ import { articleSlugSchema } from "@/lib/editorial/domain";
 import { ArticleNotFoundError } from "@/lib/editorial/errors";
 import { createFirebaseEditorialBackend } from "@/lib/editorial/firebase-admin";
 import { editorialErrorResponse, requireEditor } from "@/lib/editorial/http";
+import {
+  EDITOR_PREVIEW_COOKIE,
+  EDITOR_PREVIEW_MAX_AGE_SECONDS,
+} from "@/lib/editorial/preview-session";
 import { loadEditorialSecurityConfig } from "@/lib/editorial/security";
 
 export async function GET(request: Request) {
@@ -27,6 +31,13 @@ export async function GET(request: Request) {
     const response = NextResponse.redirect(
       new URL(`/blog/${article.slug}?preview=1`, canonicalOrigin),
     );
+    response.cookies.set(EDITOR_PREVIEW_COOKIE, article.slug, {
+      httpOnly: true,
+      maxAge: EDITOR_PREVIEW_MAX_AGE_SECONDS,
+      path: "/",
+      sameSite: "strict",
+      secure: true,
+    });
     response.headers.set("Cache-Control", "private, no-store, max-age=0");
     response.headers.set("Vary", "Cookie");
     return response;

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -24,6 +24,7 @@ import {
   getPreviewPostBySlug,
 } from "@/lib/blog";
 import { requireEditor } from "@/lib/editorial/http";
+import { readEditorialPreviewSlug } from "@/lib/editorial/preview-session";
 import { extractHeadings } from "@/lib/utils";
 import { generateBlogPostSchema } from "@/lib/schema";
 import { mdxComponents } from "@/components/blog/MDXComponents";
@@ -37,21 +38,21 @@ interface BlogPostPageProps {
   params: Promise<{ slug: string }>;
 }
 
-const isAuthorizedDraftPreview = cache(async () => {
+const getAuthorizedDraftPreviewSlug = cache(async () => {
   const mode = await draftMode();
-  if (!mode.isEnabled) return false;
+  if (!mode.isEnabled) return null;
 
   try {
     const requestHeaders = new Headers(await headers());
     await requireEditor(new Request(SITE_URL, { headers: requestHeaders }));
-    return true;
+    return readEditorialPreviewSlug(requestHeaders.get("cookie"));
   } catch {
-    return false;
+    return null;
   }
 });
 
 const getPostForRequest = cache(async (slug: string) => {
-  const preview = await isAuthorizedDraftPreview();
+  const preview = (await getAuthorizedDraftPreviewSlug()) === slug;
   return {
     post: preview
       ? await getPreviewPostBySlug(slug)

--- a/lib/editorial/preview-session.ts
+++ b/lib/editorial/preview-session.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { articleSlugSchema } from "./domain";
+
+export const EDITOR_PREVIEW_COOKIE = "__Host-shruggie_preview";
+export const EDITOR_PREVIEW_MAX_AGE_SECONDS = 8 * 60 * 60;
+
+export function readEditorialPreviewSlug(
+  cookieHeader: string | null,
+): string | null {
+  if (!cookieHeader) return null;
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValue] = part.trim().split("=");
+    if (rawName !== EDITOR_PREVIEW_COOKIE) continue;
+
+    try {
+      const parsed = articleSlugSchema.safeParse(
+        decodeURIComponent(rawValue.join("=")),
+      );
+      return parsed.success ? parsed.data : null;
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/tests/editorial/blog-preview-routing.test.ts
+++ b/tests/editorial/blog-preview-routing.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  draftMode: vi.fn(),
+  getPostBySlug: vi.fn(),
+  getPreviewPostBySlug: vi.fn(),
+  headers: vi.fn(),
+  requireEditor: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  draftMode: mocks.draftMode,
+  headers: mocks.headers,
+}));
+
+vi.mock("@/lib/blog", () => ({
+  getAllPostsMeta: vi.fn(async () => []),
+  getPostBySlug: mocks.getPostBySlug,
+  getPreviewPostBySlug: mocks.getPreviewPostBySlug,
+}));
+
+vi.mock("@/lib/editorial/http", () => ({
+  requireEditor: mocks.requireEditor,
+}));
+
+import { generateMetadata } from "../../app/blog/[slug]/page";
+
+function post(slug: string, title: string, published: boolean) {
+  return {
+    content: "## Article body",
+    meta: {
+      author: "ShruggieTech",
+      category: "Engineering",
+      date: "2026-09-06",
+      excerpt: "A sufficiently descriptive article excerpt.",
+      published,
+      readingTime: "1 min read",
+      slug,
+      title,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.draftMode.mockResolvedValue({ isEnabled: true });
+  mocks.headers.mockResolvedValue(
+    new Headers({ cookie: "__Host-shruggie_editor=session" }),
+  );
+  mocks.requireEditor.mockResolvedValue({
+    id: "editor:natalie",
+    role: "admin",
+    uid: "firebase-user",
+  });
+});
+
+describe("blog preview routing", () => {
+  it("uses published content when Draft Mode remains enabled without an exact preview slug", async () => {
+    mocks.getPostBySlug.mockResolvedValue(
+      post("published-article", "Published article", true),
+    );
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "published-article" }),
+    });
+
+    expect(metadata.title).toBe("Published article");
+    expect(mocks.getPostBySlug).toHaveBeenCalledWith("published-article");
+    expect(mocks.getPreviewPostBySlug).not.toHaveBeenCalled();
+    expect(mocks.draftMode).toHaveBeenCalledOnce();
+    expect(mocks.requireEditor).toHaveBeenCalledOnce();
+  });
+
+  it("uses authorized Firestore content for the exact preview slug", async () => {
+    mocks.headers.mockResolvedValue(
+      new Headers({
+        cookie:
+          "__Host-shruggie_editor=session; __Host-shruggie_preview=saved-draft",
+      }),
+    );
+    mocks.getPreviewPostBySlug.mockResolvedValue(
+      post("saved-draft", "Saved draft", false),
+    );
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "saved-draft" }),
+    });
+
+    expect(metadata.title).toBe("Saved draft");
+    expect(metadata.robots).toMatchObject({ index: false, follow: false });
+    expect(mocks.getPreviewPostBySlug).toHaveBeenCalledWith("saved-draft");
+    expect(mocks.getPostBySlug).not.toHaveBeenCalled();
+    expect(mocks.requireEditor).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/editorial/preview-route.test.ts
+++ b/tests/editorial/preview-route.test.ts
@@ -68,6 +68,9 @@ describe("editorial draft preview routes", () => {
     expect(response.headers.get("location")).toBe(
       "https://shruggie.tech/blog/example-article?preview=1",
     );
+    expect(response.headers.get("set-cookie")).toContain(
+      "__Host-shruggie_preview=example-article",
+    );
     expect(response.headers.get("cache-control")).toContain("no-store");
   });
 
@@ -112,5 +115,9 @@ describe("editorial draft preview routes", () => {
     expect(response.headers.get("location")).toBe(
       "https://shruggie.tech/admin",
     );
+    expect(response.headers.get("set-cookie")).toContain(
+      "__Host-shruggie_preview=",
+    );
+    expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
   });
 });

--- a/tests/editorial/security.test.ts
+++ b/tests/editorial/security.test.ts
@@ -16,6 +16,7 @@ import {
   type EditorialSecurityConfig,
   type VerifiedFirebaseIdentity,
 } from "../../lib/editorial/security";
+import { readEditorialPreviewSlug } from "../../lib/editorial/preview-session";
 
 const nowSeconds = 1_788_607_200;
 
@@ -191,5 +192,19 @@ describe("editorial security boundary", () => {
       "HttpOnly; Secure; SameSite=Strict",
     );
     expect(clearEditorSessionCookie()).toContain("Max-Age=0");
+  });
+
+  it("accepts only a valid exact preview slug cookie", () => {
+    expect(
+      readEditorialPreviewSlug(
+        "theme=dark; __Host-shruggie_preview=saved-draft; other=value",
+      ),
+    ).toBe("saved-draft");
+    expect(
+      readEditorialPreviewSlug(
+        "__Host-shruggie_preview=https%3A%2F%2Fevil.example",
+      ),
+    ).toBeNull();
+    expect(readEditorialPreviewSlug(null)).toBeNull();
   });
 });


### PR DESCRIPTION
Production regression fix for #28.

Cause: Next.js Draft Mode is site-wide. After opening a draft preview, every blog slug was sent to Firestore while the Draft Mode cookie remained active. The two existing published articles still live in repository MDX, so normal navigation returned 404.

Fix:
- bind each authorized preview session to one validated slug with a hardened host-only cookie
- require Draft Mode, a valid editor session, and an exact slug match before reading Firestore
- clear the preview slug on Exit preview
- keep ordinary published article routes repository-backed and statically generated
- add regression coverage for the lingering-Draft-Mode scenario and exact preview routing

Validation:
- npm run lint
- npm test (57 tests passing)
- npm run build
- build confirms both existing blog articles remain statically generated
- production failure reproduced before the fix