### PR TITLE
feat(cms): select registered article authors

### DIFF
--- a/app/api/admin/session/route.ts
+++ b/app/api/admin/session/route.ts
@@ -30,7 +30,11 @@ export async function GET(request: Request) {
   try {
     const principal = await requireEditor(request);
     return editorialJson({
-      editor: { id: principal.id, role: principal.role },
+      editor: {
+        author: principal.author,
+        id: principal.id,
+        role: principal.role,
+      },
     });
   } catch (error) {
     return editorialErrorResponse(error);
@@ -49,7 +53,13 @@ export async function POST(request: Request) {
     const principal = await verifyEditorIdToken(body.idToken, auth, config);
     const sessionCookie = await createEditorSessionCookie(body.idToken, auth);
     return editorialJson(
-      { editor: { id: principal.id, role: principal.role } },
+      {
+        editor: {
+          author: principal.author,
+          id: principal.id,
+          role: principal.role,
+        },
+      },
       {
         headers: {
           "Set-Cookie": serializeEditorSessionCookie(

--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -39,6 +39,7 @@ import type {
   AssetReference,
   EditorialAsset,
 } from "@/lib/editorial/domain";
+import { TEAM_AUTHORS, getAuthorByReference } from "@/lib/team";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import SignInPanel from "./SignInPanel";
@@ -208,7 +209,7 @@ export default function EditorialWorkspace() {
     if (!editor) return;
     clearDraftRecovery();
     setPersisted(null);
-    setDraft(createBlankArticle(editor.id));
+    setDraft(createBlankArticle(editor.id, editor.author));
     setDirty(false);
     setConfirmDiscard(false);
   }
@@ -544,13 +545,26 @@ function ArticleEditor({
     if (path === "title") next.title = value;
     if (path === "slug") next.slug = value;
     if (path === "excerpt") next.excerpt = value;
-    if (path === "author.name") next.author.name = value;
     if (path === "category") next.category = value;
     if (path === "body.source") next.body.source = value;
     onChange(next);
     setErrors((current) => {
       const updated = { ...current };
       delete updated[path];
+      return updated;
+    });
+    setMessage(null);
+  }
+
+  function selectAuthor(authorId: string) {
+    const author = TEAM_AUTHORS.find((candidate) => candidate.id === authorId);
+    if (!author) return;
+    const next = structuredClone(draft);
+    next.author = { ...author };
+    onChange(next);
+    setErrors((current) => {
+      const updated = { ...current };
+      delete updated["author.name"];
       return updated;
     });
     setMessage(null);
@@ -786,21 +800,43 @@ function ArticleEditor({
                 />
               </Field>
               <Field
-                label="Author name"
+                label="Author"
                 path="author.name"
                 error={errors["author.name"]}
+                hint={
+                  getAuthorByReference(draft.author)
+                    ? "Controls the byline, Written by card, and article metadata."
+                    : draft.author.name
+                      ? `“${draft.author.name}” has no registered author profile. Select an author to add the Written by card.`
+                      : "Controls the byline, Written by card, and article metadata."
+                }
               >
-                <input
+                <select
                   id="author.name"
-                  value={draft.author.name}
+                  value={
+                    getAuthorByReference(draft.author) ? draft.author.id : ""
+                  }
                   disabled={readOnly}
                   aria-invalid={Boolean(errors["author.name"])}
                   aria-describedby={
-                    errors["author.name"] ? "author.name-error" : undefined
+                    errors["author.name"]
+                      ? "author.name-error"
+                      : "author.name-hint"
                   }
-                  onChange={(event) => field("author.name", event.target.value)}
+                  onChange={(event) => selectAuthor(event.target.value)}
                   className={inputClass}
-                />
+                >
+                  <option value="" disabled>
+                    {draft.author.name
+                      ? `Select an author — “${draft.author.name}” has no profile`
+                      : "Select an author"}
+                  </option>
+                  {TEAM_AUTHORS.map((author) => (
+                    <option key={author.id} value={author.id}>
+                      {author.name}
+                    </option>
+                  ))}
+                </select>
               </Field>
               <Field
                 label="Excerpt"

--- a/lib/editorial/article-form.ts
+++ b/lib/editorial/article-form.ts
@@ -1,9 +1,11 @@
 import { articleSchemaV1, type Article } from "./domain";
+import { getAuthorByReference, type TeamAuthorReference } from "../team";
 
 export type ArticleFieldErrors = Record<string, string>;
 
 export function createBlankArticle(
   editorId: string,
+  author: TeamAuthorReference | null = null,
   now = new Date(),
 ): Article {
   const timestamp = now.toISOString();
@@ -13,7 +15,7 @@ export function createBlankArticle(
     slug: "",
     title: "",
     excerpt: "",
-    author: { id: editorId, name: "" },
+    author: author ?? { id: editorId, name: "" },
     category: "",
     body: { format: "markdown", source: "" },
     state: "draft",
@@ -69,11 +71,15 @@ export function articleForSave(
 
 export function validateArticleForSave(article: Article): ArticleFieldErrors {
   const result = articleSchemaV1.safeParse(article);
-  if (result.success) return {};
   const errors: ArticleFieldErrors = {};
-  for (const issue of result.error.issues) {
-    const field = issue.path.join(".") || "form";
-    errors[field] ??= issue.message;
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const field = issue.path.join(".") || "form";
+      errors[field] ??= issue.message;
+    }
+  }
+  if (!getAuthorByReference(article.author)) {
+    errors["author.name"] ??= "Select a registered ShruggieTech author.";
   }
   return errors;
 }

--- a/lib/editorial/client-api.ts
+++ b/lib/editorial/client-api.ts
@@ -1,7 +1,9 @@
 import type { Article, EditorialAsset } from "./domain";
 import type { EditorialRole } from "./audit";
+import type { TeamAuthorReference } from "../team";
 
 export interface EditorialEditor {
+  author: TeamAuthorReference | null;
   id: string;
   role: EditorialRole;
 }

--- a/lib/editorial/security.ts
+++ b/lib/editorial/security.ts
@@ -4,6 +4,8 @@ import { createHash, randomUUID } from "node:crypto";
 
 import { z } from "zod";
 
+import { getAuthorReferenceByEmail, type TeamAuthorReference } from "../team";
+
 import {
   editorialMutationContextSchema,
   type EditorialMutationContext,
@@ -67,6 +69,7 @@ export interface EditorialSecurityConfig {
 }
 
 export interface EditorPrincipal {
+  author: TeamAuthorReference | null;
   id: string;
   role: EditorialRole;
   uid: string;
@@ -211,7 +214,12 @@ export function authorizeEditorIdentity(
       403,
     );
   }
-  return { id: principalId(identity.uid), role, uid: identity.uid };
+  return {
+    author: getAuthorReferenceByEmail(email),
+    id: principalId(identity.uid),
+    role,
+    uid: identity.uid,
+  };
 }
 
 export async function verifyEditorIdToken(

--- a/lib/team.ts
+++ b/lib/team.ts
@@ -17,6 +17,7 @@ export interface SocialLink {
 }
 
 export interface TeamMemberData {
+  id: string;
   name: string;
   title: string;
   description: string;
@@ -26,43 +27,106 @@ export interface TeamMemberData {
 
 export const TEAM_MEMBERS: TeamMemberData[] = [
   {
+    id: "william",
     name: "William Thompson",
     title: "Co-Founder & Chief Architect",
     description:
       "Software architect, systems designer, and the author of ShruggieTech's internal products and published research. Background in cryptography, electronic warfare, and high-performance computing. Writes specifications that AI agents can execute without asking questions.",
     image: "https://cdn.shruggie.tech/avatars/william-thompson-toon.jpg",
     socials: [
-      { href: "https://www.linkedin.com/in/willthompsonpro/", label: "LinkedIn", icon: "Linkedin" },
-      { href: "https://github.com/h8rt3rmin8r", label: "GitHub", icon: "Github" },
+      {
+        href: "https://www.linkedin.com/in/willthompsonpro/",
+        label: "LinkedIn",
+        icon: "Linkedin",
+      },
+      {
+        href: "https://github.com/h8rt3rmin8r",
+        label: "GitHub",
+        icon: "Github",
+      },
     ],
   },
   {
+    id: "natalie",
     name: "Natalie Thompson",
     title: "Co-Founder & COO",
     description:
       "Self-taught full-stack developer, client relationship lead, and the person who makes everything actually happen. Pairs deep technical ability with the soft skills that keep complex projects moving forward. From branding to business development, she runs point on it all.",
     image: "https://cdn.shruggie.tech/avatars/natalie-thompson-toon.jpg",
     socials: [
-      { href: "https://www.linkedin.com/in/cryptasian/", label: "LinkedIn", icon: "Linkedin" },
-      { href: "https://www.facebook.com/cryptasian", label: "Facebook", icon: "Facebook" },
-      { href: "https://www.instagram.com/cryptasian/", label: "Instagram", icon: "Instagram" },
-      { href: "https://github.com/cryptasian", label: "GitHub", icon: "Github" },
+      {
+        href: "https://www.linkedin.com/in/cryptasian/",
+        label: "LinkedIn",
+        icon: "Linkedin",
+      },
+      {
+        href: "https://www.facebook.com/cryptasian",
+        label: "Facebook",
+        icon: "Facebook",
+      },
+      {
+        href: "https://www.instagram.com/cryptasian/",
+        label: "Instagram",
+        icon: "Instagram",
+      },
+      {
+        href: "https://github.com/cryptasian",
+        label: "GitHub",
+        icon: "Github",
+      },
     ],
   },
   {
+    id: "josiah",
     name: "Josiah Thompson",
     title: "Founders Assistant",
     description:
       "Josiah contributes to ShruggieTech's production work, assisting with social media content creation, blog article drafting, and website maintenance. His role is designed to build real professional skills early, equipping him with the technical fluency and operational discipline for a career in technology.",
     image: "https://cdn.shruggie.tech/avatars/josiah-thompson-toon.jpg",
     socials: [
-      { href: "https://twitch.tv/notratmaster", label: "Twitch", icon: "Twitch" },
-      { href: "https://www.youtube.com/@notratmaster", label: "YouTube", icon: "Youtube" },
+      {
+        href: "https://twitch.tv/notratmaster",
+        label: "Twitch",
+        icon: "Twitch",
+      },
+      {
+        href: "https://www.youtube.com/@notratmaster",
+        label: "YouTube",
+        icon: "Youtube",
+      },
     ],
   },
 ];
 
+export interface TeamAuthorReference {
+  id: string;
+  name: string;
+}
+
+export const TEAM_AUTHORS: TeamAuthorReference[] = TEAM_MEMBERS.map(
+  ({ id, name }) => ({ id: `team:${id}`, name }),
+);
+
 /** Look up a team member by exact display name (e.g. a blog post's author). */
 export function getAuthorByName(name: string): TeamMemberData | undefined {
   return TEAM_MEMBERS.find((member) => member.name === name);
+}
+
+/** Resolve a canonical article author only when both its stable ID and name match. */
+export function getAuthorByReference(
+  reference: TeamAuthorReference,
+): TeamMemberData | undefined {
+  return TEAM_MEMBERS.find(
+    (member) =>
+      `team:${member.id}` === reference.id && member.name === reference.name,
+  );
+}
+
+/** Map an approved staff identity to its public author profile without exposing email. */
+export function getAuthorReferenceByEmail(
+  email: string,
+): TeamAuthorReference | null {
+  const [handle, domain, ...rest] = email.trim().toLowerCase().split("@");
+  if (domain !== "shruggie.tech" || rest.length > 0) return null;
+  return TEAM_AUTHORS.find(({ id }) => id === `team:${handle}`) ?? null;
 }

--- a/tests/editorial/fixtures.ts
+++ b/tests/editorial/fixtures.ts
@@ -21,7 +21,7 @@ export function articleFixture(overrides: Partial<Article> = {}): Article {
     slug: "example-article",
     title: "An example article",
     excerpt: "A sufficiently descriptive excerpt for an example article.",
-    author: { id: "editor:natalie", name: "Natalie Thompson" },
+    author: { id: "team:natalie", name: "Natalie Thompson" },
     category: "Engineering",
     body: {
       format: "markdown",

--- a/tests/editorial/security.test.ts
+++ b/tests/editorial/security.test.ts
@@ -97,6 +97,22 @@ describe("editorial security boundary", () => {
     ).toThrowError(/verified/);
   });
 
+  it("maps a signed-in staff account to its public author profile", () => {
+    const natalie = authorizeEditorIdentity(
+      identity({ email: "natalie@shruggie.tech" }),
+      {
+        ...config(),
+        adminEmails: new Set(["natalie@shruggie.tech"]),
+      },
+    );
+
+    expect(natalie.author).toEqual({
+      id: "team:natalie",
+      name: "Natalie Thompson",
+    });
+    expect(JSON.stringify(natalie)).not.toContain("natalie@shruggie.tech");
+  });
+
   it("checks revocation and recent authentication before issuing a session", async () => {
     const auth = verifier();
     await expect(

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -35,7 +35,13 @@ function sessionAndWorkspaceFetch(
     const url = String(input);
     const method = init?.method ?? "GET";
     if (url === "/api/admin/session" && method === "GET") {
-      return json({ editor: { id: "editor:natalie", role: "admin" } });
+      return json({
+        editor: {
+          author: { id: "team:natalie", name: "Natalie Thompson" },
+          id: "editor:natalie",
+          role: "admin",
+        },
+      });
     }
     if (url === "/api/admin/articles?limit=100") {
       return json({ articles: initialArticles });
@@ -154,7 +160,9 @@ describe("EditorialWorkspace", () => {
       "a-keyboard-authored-article",
     );
     await user.type(screen.getByLabelText("Category"), "Engineering");
-    await user.type(screen.getByLabelText("Author name"), "Natalie Thompson");
+    const author = screen.getByLabelText("Author");
+    expect(author).toHaveValue("team:natalie");
+    await user.selectOptions(author, "team:william");
     await user.type(
       screen.getByLabelText("Excerpt"),
       "A complete excerpt written entirely with accessible browser controls.",
@@ -180,6 +188,11 @@ describe("EditorialWorkspace", () => {
         String(input) === "/api/admin/articles" && init?.method === "POST",
     );
     expect(post).toBeTruthy();
+    const saved = JSON.parse(String(post?.[1]?.body)) as { article: Article };
+    expect(saved.article.author).toEqual({
+      id: "team:william",
+      name: "William Thompson",
+    });
     expect(preview).toBeEnabled();
     expect(
       screen.getByText("Preview opens the saved draft without publishing."),
@@ -264,6 +277,31 @@ describe("EditorialWorkspace", () => {
     expect(screen.getByLabelText("Excerpt")).toHaveFocus();
   });
 
+  it("flags a legacy free-text author until a registered profile is selected", async () => {
+    const legacy = articleFixture({
+      author: { id: "editor:legacy", name: "ShruggieTech" },
+    });
+    globalThis.fetch = sessionAndWorkspaceFetch([legacy]);
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /Edit An example article/ }),
+    );
+
+    const author = screen.getByLabelText("Author");
+    expect(author).toHaveValue("");
+    expect(
+      screen.getByText(/“ShruggieTech” has no registered author profile/),
+    ).toBeInTheDocument();
+
+    await user.selectOptions(author, "team:josiah");
+    expect(author).toHaveValue("team:josiah");
+    expect(
+      screen.getByText(/Controls the byline, Written by card/),
+    ).toBeInTheDocument();
+  });
+
   it("enforces upload fields and selects the uploaded asset", async () => {
     const user = userEvent.setup();
     render(<EditorialWorkspace />);
@@ -323,7 +361,13 @@ describe("EditorialWorkspace", () => {
         const url = String(input);
         const method = init?.method ?? "GET";
         if (url === "/api/admin/session")
-          return json({ editor: { id: "editor:natalie", role: "editor" } });
+          return json({
+            editor: {
+              author: { id: "team:natalie", name: "Natalie Thompson" },
+              id: "editor:natalie",
+              role: "editor",
+            },
+          });
         if (url === "/api/admin/articles?limit=100")
           return json({ articles: [current] });
         if (url === "/api/admin/assets") return json({ assets: [] });
@@ -368,7 +412,13 @@ describe("EditorialWorkspace", () => {
         const url = String(input);
         const method = init?.method ?? "GET";
         if (url === "/api/admin/session")
-          return json({ editor: { id: "editor:natalie", role: "editor" } });
+          return json({
+            editor: {
+              author: { id: "team:natalie", name: "Natalie Thompson" },
+              id: "editor:natalie",
+              role: "editor",
+            },
+          });
         if (url === "/api/admin/articles?limit=100")
           return json({ articles: [current] });
         if (url === "/api/admin/assets") return json({ assets: [] });

--- a/tests/team-authors.test.ts
+++ b/tests/team-authors.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { generateBlogPostSchema } from "../lib/schema";
+import {
+  TEAM_AUTHORS,
+  getAuthorByReference,
+  getAuthorReferenceByEmail,
+} from "../lib/team";
+
+describe("registered blog authors", () => {
+  it("resolves every selectable author to a complete public profile", () => {
+    expect(TEAM_AUTHORS).toHaveLength(3);
+    for (const author of TEAM_AUTHORS) {
+      const profile = getAuthorByReference(author);
+      expect(profile).toMatchObject({
+        name: author.name,
+        title: expect.any(String),
+        description: expect.any(String),
+        image: expect.any(String),
+        socials: expect.any(Array),
+      });
+    }
+  });
+
+  it("maps staff email identities without accepting aliases or other domains", () => {
+    expect(getAuthorReferenceByEmail(" Natalie@Shruggie.Tech ")).toEqual({
+      id: "team:natalie",
+      name: "Natalie Thompson",
+    });
+    expect(getAuthorReferenceByEmail("editor@shruggie.tech")).toBeNull();
+    expect(getAuthorReferenceByEmail("natalie@example.com")).toBeNull();
+  });
+
+  it("uses the same profile for BlogPosting author metadata", () => {
+    const schema = generateBlogPostSchema({
+      title: "A test article",
+      date: "2026-09-07",
+      author: "Natalie Thompson",
+      excerpt: "A test article with a registered author profile.",
+      slug: "test-article",
+    });
+
+    expect(schema.author).toMatchObject({
+      "@type": "Person",
+      name: "Natalie Thompson",
+      jobTitle: "Co-Founder & COO",
+      image: expect.stringContaining("natalie-thompson"),
+      sameAs: expect.arrayContaining([
+        "https://www.linkedin.com/in/cryptasian/",
+      ]),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- default new drafts to the signed-in staff member's public author profile
- replace the free-text author field with a registered-author dropdown
- preserve stable author IDs so previews, Written by cards, and BlogPosting metadata use the same profile
- flag legacy free-text author values until a registered profile is selected

## Verification
- npm run lint
- npm test (58 Vitest tests + 4 contrast tests)
- npm run build

Closes #65