### PR TITLE
fix(cms): clarify registered author placeholder

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -827,7 +827,7 @@ function ArticleEditor({
                   className={inputClass}
                 >
                   <option value="" disabled>
-                    {draft.author.name
+                    {!getAuthorByReference(draft.author) && draft.author.name
                       ? `Select an author — “${draft.author.name}” has no profile`
                       : "Select an author"}
                   </option>

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -162,6 +162,12 @@ describe("EditorialWorkspace", () => {
     await user.type(screen.getByLabelText("Category"), "Engineering");
     const author = screen.getByLabelText("Author");
     expect(author).toHaveValue("team:natalie");
+    expect(
+      screen.getByRole("option", { name: "Select an author" }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByRole("option", { name: /Natalie Thompson.*no profile/ }),
+    ).not.toBeInTheDocument();
     await user.selectOptions(author, "team:william");
     await user.type(
       screen.getByLabelText("Excerpt"),


### PR DESCRIPTION
## Summary
- show the neutral placeholder when a registered author is already selected
- retain the missing-profile warning only for legacy free-text author values
- add regression coverage for the signed-in default state

## Verification
- npx vitest run tests/editorial/workspace.test.tsx
- npm run lint

Closes #65