### PR TITLE
fix(cms): restore the full-width article editor

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -732,7 +732,7 @@ function ArticleEditor({
         </div>
       )}
 
-      <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_22rem]">
+      <div className="space-y-8">
         <form onSubmit={saveDraft} noValidate className="space-y-8">
           <Card hover={false}>
             <p className="text-body-xs text-accent font-mono tracking-[0.16em] uppercase">
@@ -909,10 +909,12 @@ function ArticleEditor({
             onSessionFailure={onSessionFailure}
           />
 
-          <div className="border-border bg-bg-elevated/95 sticky bottom-4 z-10 flex flex-col gap-3 rounded-xl border p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center">
+          <div className="border-border bg-bg-elevated/95 sticky bottom-4 z-10 flex flex-wrap items-center gap-3 rounded-xl border p-4 shadow-xl backdrop-blur">
             <Button
               type="submit"
+              size="sm"
               disabled={readOnly || saveState === "loading"}
+              className="shrink-0 whitespace-nowrap"
             >
               <Save aria-hidden="true" className="mr-2" size={18} />{" "}
               {saveState === "loading" ? "Saving…" : "Save draft"}
@@ -920,8 +922,10 @@ function ArticleEditor({
             <Button
               type="button"
               variant="secondary"
+              size="sm"
               disabled={!persisted || dirty}
               aria-describedby="preview-note"
+              className="shrink-0 whitespace-nowrap"
               onClick={() => {
                 if (!persisted || dirty) return;
                 window.open(
@@ -933,12 +937,18 @@ function ArticleEditor({
             >
               <Eye aria-hidden="true" className="mr-2" size={18} /> Preview
             </Button>
-            <Button type="button" variant="secondary" disabled>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled
+              className="shrink-0 whitespace-nowrap"
+            >
               Publish
             </Button>
             <p
               id="preview-note"
-              className="text-body-xs text-text-secondary sm:ml-auto"
+              className="text-body-xs text-text-secondary min-w-0 flex-1 sm:text-right"
             >
               {!persisted
                 ? "Save the draft to preview."
@@ -1217,10 +1227,7 @@ function RevisionHistory({
     (item) => item.revision.number === selected,
   );
   return (
-    <aside
-      aria-labelledby="revision-history-heading"
-      className="xl:sticky xl:top-24 xl:self-start"
-    >
+    <aside aria-labelledby="revision-history-heading">
       <Card hover={false}>
         <h2
           id="revision-history-heading"
@@ -1253,7 +1260,7 @@ function RevisionHistory({
         ) : (
           <fieldset className="mt-4">
             <legend className="sr-only">Select an article revision</legend>
-            <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+            <div className="grid max-h-72 gap-2 overflow-y-auto pr-1 md:grid-cols-2 xl:grid-cols-3">
               {revisions.map((revision) => (
                 <label
                   key={revision.revision.number}

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -263,6 +263,32 @@ describe("EditorialWorkspace", () => {
     document.removeEventListener("wheel", pageWheel);
   });
 
+  it("keeps the writing canvas full width with compact actions and history below", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: "New article" }),
+    );
+
+    const form = container.querySelector("form");
+    const history = screen.getByRole("complementary", {
+      name: "Revision history",
+    });
+    const save = screen.getByRole("button", { name: "Save draft" });
+
+    expect(form).not.toBeNull();
+    expect(form?.parentElement).toHaveClass("space-y-8");
+    expect(form?.parentElement).not.toHaveClass(
+      "xl:grid-cols-[minmax(0,1fr)_22rem]",
+    );
+    expect(form?.compareDocumentPosition(history) ?? 0).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(history).not.toHaveClass("xl:sticky");
+    expect(save).toHaveClass("shrink-0", "whitespace-nowrap", "px-4", "py-2");
+    expect(save.parentElement).toHaveClass("flex-wrap", "items-center");
+  });
+
   it("identifies invalid fields and preserves unsaved work", async () => {
     const user = userEvent.setup();
     render(<EditorialWorkspace />);


### PR DESCRIPTION
## Summary
- remove the right-hand revision rail so the writing form uses the full workspace width
- move revision history below the article form and arrange revisions responsively
- make save, preview, and publish controls compact with non-wrapping labels
- preserve sticky actions and revision restore behavior

## Verification
- npm run lint
- npm test (59 Vitest tests + 4 contrast tests)
- npm run build

Closes #68