### PR TITLE
fix(cms): restore image uploads and permit blank alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Editorial image uploads and decorative alt text**: restored authenticated
+  Cloud Storage writes from the shared article media picker, retained
+  actionable server diagnostics for provider failures, and allowed trimmed
+  empty alt text to persist and render as `alt=""` without affecting descriptive
+  alt text or media reuse
 - **Light-theme green contrast**: added an accessible `#037B40` foreground/focus token for green text, links, and focus indicators on `#F8F8F6`, while preserving bright `#2BCC73` as the dark-surface identity accent; added automated contrast and semantic-token regression coverage
 - **Specification framework version**: removed the stale Next.js 15 reference from §1.1 and made the framework entry version-agnostic so `package.json` remains the canonical installed version
 - **Blog code blocks**: merge Shiki's generated class names with `CopyCodeBlock` container utilities so syntax highlighting keeps its theme while rounded corners, borders, padding, and overflow styling remain intact

--- a/app/api/admin/assets/route.ts
+++ b/app/api/admin/assets/route.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-import { editorialIdSchema, MAX_ASSET_BYTES } from "@/lib/editorial/domain";
+import {
+  editorialIdSchema,
+  imageAltTextSchema,
+  MAX_ASSET_BYTES,
+} from "@/lib/editorial/domain";
 import { EditorialValidationError } from "@/lib/editorial/errors";
 import { createFirebaseEditorialBackend } from "@/lib/editorial/firebase-admin";
 import {
@@ -18,7 +22,7 @@ export const dynamic = "force-dynamic";
 
 const assetFieldsSchema = z
   .object({
-    altText: z.string().trim().min(5).max(300),
+    altText: imageAltTextSchema,
     articleId: editorialIdSchema,
     id: editorialIdSchema,
   })

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -34,9 +34,16 @@ import TableOfContents from "@/components/blog/TableOfContents";
 import AuthorBox from "@/components/blog/AuthorBox";
 import PostCTA from "@/components/blog/PostCTA";
 import JsonLd from "@/components/shared/JsonLd";
+import type { PostMeta } from "@/lib/blog";
 
 interface BlogPostPageProps {
   params: Promise<{ slug: string }>;
+}
+
+export function featuredImageAlt(
+  meta: Pick<PostMeta, "featuredImageAlt" | "title">,
+): string {
+  return meta.featuredImageAlt ?? meta.title;
 }
 
 const getAuthorizedDraftPreviewSlug = cache(async () => {
@@ -180,7 +187,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             <div className="border-border bg-bg-secondary overflow-hidden rounded-lg border">
               <Image
                 src={meta.featuredImage!}
-                alt={meta.featuredImageAlt ?? meta.title}
+                alt={featuredImageAlt(meta)}
                 width={1400}
                 height={788}
                 className="h-auto w-full"

--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -1254,9 +1254,14 @@ function AssetEditor({
   }
 
   async function upload() {
-    if (!pickerSlot || !file || alt.trim().length < 5) {
+    const normalizedAlt = alt.trim();
+    if (
+      !pickerSlot ||
+      !file ||
+      (normalizedAlt.length > 0 && normalizedAlt.length < 5)
+    ) {
       setError(
-        "Choose an image and provide at least five characters of descriptive alt text.",
+        "Choose an image and provide at least five characters of descriptive alt text, or leave alt text blank when the image is decorative.",
       );
       return;
     }
@@ -1264,7 +1269,7 @@ function AssetEditor({
     setError(null);
     try {
       const asset = await uploadEditorialAsset({
-        altText: alt,
+        altText: normalizedAlt,
         articleId: article.id,
         file,
       });
@@ -1288,7 +1293,8 @@ function AssetEditor({
       <h2 className="font-display text-xl font-bold">Images</h2>
       <p className="text-body-sm text-text-secondary mt-2">
         JPEG, PNG, WebP, or AVIF. Maximum 5 MiB and 6000 pixels per side. Alt
-        text is required.
+        text should describe informative images; leave it blank for decorative
+        images.
       </p>
       <div className="mt-6 grid gap-5 md:grid-cols-2">
         {(["featuredImage", "ogImage"] as const).map((imageSlot) => {
@@ -1371,7 +1377,6 @@ function AssetEditor({
                   <input
                     id={`${imageSlot}-alt`}
                     value={value.altText}
-                    minLength={5}
                     maxLength={300}
                     disabled={readOnly}
                     aria-invalid={Boolean(errors[`${imageSlot}.altText`])}
@@ -1563,10 +1568,9 @@ function AssetEditor({
                       />
                     </label>
                     <label className="text-body-sm">
-                      Descriptive alt text
+                      Alt text (leave blank if decorative)
                       <input
                         value={alt}
-                        minLength={5}
                         maxLength={300}
                         onChange={(event) => setAlt(event.target.value)}
                         className={inputClass}

--- a/docs/editorial/content-contract.md
+++ b/docs/editorial/content-contract.md
@@ -64,7 +64,9 @@ The public contract stores a stable project URL at
 `https://shruggie.tech/media/{assetId}` rather than a provider URL. Asset records
 also preserve the original filename, detected type, byte size, dimensions,
 contextual default alt text, SHA-256 checksum, creation metadata, and private
-storage path.
+storage path. Alt text is trimmed when stored. An intentionally blank value is
+preserved as `""` for decorative images; non-empty values remain descriptive
+and at least five characters long.
 
 ## Adapter boundary
 

--- a/docs/operations/firebase-production.md
+++ b/docs/operations/firebase-production.md
@@ -82,6 +82,13 @@ The production environment also provides `GCP_PROJECT_NUMBER`,
 `GCP_WORKLOAD_IDENTITY_POOL_PROVIDER_ID`. These values identify the workload
 identity trust and are configuration, not private keys.
 
+Cloud Storage must receive the validated external-account configuration rather
+than the already constructed Firestore auth client. The installed clients use
+different major versions of `google-auth-library`; passing the newer client
+object into Storage can silently omit the Authorization header and make writes
+appear anonymous. Provider failures remain logged by the editorial route while
+the browser receives only the project-owned, non-sensitive error response.
+
 ## Authentication gate
 
 Firebase Authentication is initialized with Google as its only sign-in provider.

--- a/lib/editorial/domain.ts
+++ b/lib/editorial/domain.ts
@@ -40,6 +40,15 @@ const isoDateTimeSchema = z.string().datetime({ offset: true });
 
 export const articleStateSchema = z.enum(["draft", "published", "archived"]);
 
+export const imageAltTextSchema = z
+  .string()
+  .trim()
+  .max(300)
+  .refine(
+    (value) => value.length === 0 || value.length >= 5,
+    "Describe the image with at least five characters, or leave alt text blank when the image is decorative.",
+  );
+
 export const assetReferenceSchema = z
   .object({
     assetId: editorialIdSchema,
@@ -59,7 +68,7 @@ export const assetReferenceSchema = z
           })(),
         "Use a root-relative path or HTTPS delivery URL.",
       ),
-    altText: z.string().trim().min(5).max(300),
+    altText: imageAltTextSchema,
   })
   .strict();
 
@@ -194,7 +203,7 @@ export const editorialAssetSchemaV1 = z
     sizeBytes: z.number().int().positive().max(MAX_ASSET_BYTES),
     width: z.number().int().positive().max(MAX_ASSET_DIMENSION),
     height: z.number().int().positive().max(MAX_ASSET_DIMENSION),
-    altText: z.string().trim().min(5).max(300),
+    altText: imageAltTextSchema,
     checksumSha256: z.string().regex(/^[a-f0-9]{64}$/),
     storagePath: z
       .string()

--- a/lib/editorial/firebase-admin.ts
+++ b/lib/editorial/firebase-admin.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import { FirebaseAssetStore } from "./firebase-asset-store";
 import { FirestoreArticleRepository } from "./firestore-article-repository";
 import {
+  createVercelExternalAccountOptions,
   createVercelExternalAccountClient,
   createVercelGoogleCredential,
 } from "./vercel-google-credential";
@@ -71,7 +72,10 @@ export function createFirebaseEditorialBackend() {
       projectId: environment.FIREBASE_PROJECT_ID,
     });
     bucket = new Storage({
-      authClient: authClient as never,
+      // Storage 7 uses google-auth-library 9 internally, while Firestore uses
+      // v11. Supplying the plain external-account configuration lets Storage
+      // construct a version-compatible client that reliably adds Authorization.
+      credentials: createVercelExternalAccountOptions(),
       projectId: environment.FIREBASE_PROJECT_ID,
     }).bucket(environment.FIREBASE_STORAGE_BUCKET);
   } else {

--- a/lib/editorial/mdx-article-reader.ts
+++ b/lib/editorial/mdx-article-reader.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import {
   ARTICLE_SCHEMA_VERSION,
   articleSlugSchema,
+  imageAltTextSchema,
   parseArticle,
   type Article,
   type AssetReference,
@@ -31,9 +32,9 @@ const frontmatterSchema = z
     excerpt: z.string().trim().min(10).max(400),
     published: z.boolean().default(true),
     ogImage: z.string().trim().min(1).optional(),
-    ogImageAlt: z.string().trim().min(5).max(300).optional(),
+    ogImageAlt: imageAltTextSchema.optional(),
     featuredImage: z.string().trim().min(1).optional(),
-    featuredImageAlt: z.string().trim().min(5).max(300).optional(),
+    featuredImageAlt: imageAltTextSchema.optional(),
   })
   .strict();
 

--- a/lib/editorial/vercel-google-credential.ts
+++ b/lib/editorial/vercel-google-credential.ts
@@ -5,7 +5,6 @@ import type { Credential, GoogleOAuthAccessToken } from "firebase-admin/app";
 import {
   ExternalAccountClient,
   type BaseExternalAccountClient,
-  type IdentityPoolClientOptions,
 } from "google-auth-library";
 import { z } from "zod";
 
@@ -18,6 +17,17 @@ const configurationSchema = z.object({
 
 export type VercelGoogleCredentialConfig = z.infer<typeof configurationSchema>;
 
+export interface VercelExternalAccountOptions {
+  audience: string;
+  service_account_impersonation_url: string;
+  subject_token_supplier: {
+    getSubjectToken: () => Promise<string>;
+  };
+  subject_token_type: "urn:ietf:params:oauth:token-type:jwt";
+  token_url: "https://sts.googleapis.com/v1/token";
+  type: "external_account";
+}
+
 export function loadVercelGoogleCredentialConfig(
   environment: Record<string, string | undefined> = process.env,
 ): VercelGoogleCredentialConfig {
@@ -27,7 +37,7 @@ export function loadVercelGoogleCredentialConfig(
 export function externalAccountOptions(
   configuration: VercelGoogleCredentialConfig,
   subjectTokenSupplier = getVercelOidcToken,
-): IdentityPoolClientOptions {
+): VercelExternalAccountOptions {
   const {
     GCP_PROJECT_NUMBER: projectNumber,
     GCP_SERVICE_ACCOUNT_EMAIL: serviceAccountEmail,
@@ -84,12 +94,16 @@ export function createVercelGoogleCredential(
   );
 }
 
+export function createVercelExternalAccountOptions(
+  environment: Record<string, string | undefined> = process.env,
+): VercelExternalAccountOptions {
+  return externalAccountOptions(loadVercelGoogleCredentialConfig(environment));
+}
+
 export function createVercelExternalAccountClient(
   environment: Record<string, string | undefined> = process.env,
 ): BaseExternalAccountClient {
-  const options = externalAccountOptions(
-    loadVercelGoogleCredentialConfig(environment),
-  );
+  const options = createVercelExternalAccountOptions(environment);
   const client = ExternalAccountClient.fromJSON(options);
   if (!client) {
     throw new Error("Unable to initialize Vercel workload identity.");

--- a/tests/editorial/asset-route.test.ts
+++ b/tests/editorial/asset-route.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContentUnavailableError } from "../../lib/editorial/errors";
+
+const mocks = vi.hoisted(() => ({
+  assertCanonicalMutationOrigin: vi.fn(),
+  put: vi.fn(),
+  requireEditor: vi.fn(),
+}));
+
+vi.mock("../../lib/editorial/firebase-admin", () => ({
+  createFirebaseEditorialBackend: () => ({
+    assets: { put: mocks.put },
+  }),
+  getFirebaseEditorialAuth: vi.fn(),
+}));
+
+vi.mock("../../lib/editorial/http", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../../lib/editorial/http")>();
+  return { ...actual, requireEditor: mocks.requireEditor };
+});
+
+vi.mock("../../lib/editorial/security", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../../lib/editorial/security")>();
+  return {
+    ...actual,
+    assertCanonicalMutationOrigin: mocks.assertCanonicalMutationOrigin,
+    loadEditorialSecurityConfig: () => ({
+      canonicalOrigin: "https://shruggie.tech",
+    }),
+  };
+});
+
+import { POST } from "../../app/api/admin/assets/route";
+
+function uploadRequest(altText: string): Request {
+  const form = new FormData();
+  form.set("altText", altText);
+  form.set("articleId", "article:example");
+  form.set(
+    "file",
+    new File([new Uint8Array([137, 80, 78, 71])], "hero.png", {
+      type: "image/png",
+    }),
+  );
+  form.set("id", "asset:hero");
+  return new Request("https://shruggie.tech/api/admin/assets", {
+    body: form,
+    headers: { origin: "https://shruggie.tech" },
+    method: "POST",
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireEditor.mockResolvedValue({ id: "editor:natalie" });
+  mocks.put.mockImplementation(async (input) => ({
+    schemaVersion: 1,
+    id: input.id,
+    articleId: input.articleId,
+    originalFileName: input.fileName,
+    contentType: input.contentType,
+    sizeBytes: input.bytes.length,
+    width: 1,
+    height: 1,
+    altText: input.altText,
+    checksumSha256: "a".repeat(64),
+    storagePath: `articles/${input.articleId}/${input.id}.png`,
+    deliveryUrl: `https://shruggie.tech/media/${input.id}`,
+    createdAt: input.createdAt,
+    createdBy: input.createdBy,
+  }));
+});
+
+describe("POST /api/admin/assets", () => {
+  it.each([
+    ["whitespace-only decorative alt text", " \t ", ""],
+    [
+      "descriptive alt text",
+      "  A green terminal window showing a successful build  ",
+      "A green terminal window showing a successful build",
+    ],
+  ])("uploads an image with %s", async (_label, submitted, expected) => {
+    const response = await POST(uploadRequest(submitted));
+
+    expect(response.status).toBe(201);
+    expect(mocks.put).toHaveBeenCalledWith(
+      expect.objectContaining({ altText: expected }),
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      asset: { altText: expected, id: "asset:hero" },
+    });
+  });
+
+  it("keeps the provider cause in server diagnostics but returns a safe failure", async () => {
+    const providerError = Object.assign(
+      new Error("Anonymous caller is missing storage.objects.create"),
+      { code: 401 },
+    );
+    mocks.put.mockRejectedValue(
+      new ContentUnavailableError("store an article image", providerError),
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const response = await POST(uploadRequest("A descriptive image"));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({
+      error: {
+        code: "CONTENT_UNAVAILABLE",
+        message:
+          "Editorial storage is unavailable while attempting to store an article image.",
+        retryable: true,
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain("storage.objects.create");
+    expect(consoleError).toHaveBeenCalledWith(
+      "Retryable editorial route error",
+      expect.objectContaining({ cause: providerError }),
+    );
+  });
+});

--- a/tests/editorial/assets-and-export.test.ts
+++ b/tests/editorial/assets-and-export.test.ts
@@ -63,7 +63,20 @@ describe("AssetStore contract", () => {
     });
   });
 
-  it("rejects mismatched types and inadequate alternatives", async () => {
+  it("normalizes and stores an intentionally blank decorative alternative", async () => {
+    const store = new InMemoryAssetStore();
+    const asset = await store.put({
+      ...uploadInput(await pngBytes()),
+      altText: " \t ",
+    });
+
+    expect(asset.altText).toBe("");
+    await expect(store.getById(asset.id)).resolves.toMatchObject({
+      altText: "",
+    });
+  });
+
+  it("rejects mismatched types and inadequate non-empty alternatives", async () => {
     const store = new InMemoryAssetStore();
     const bytes = await pngBytes();
     await expect(

--- a/tests/editorial/blog-preview-routing.test.ts
+++ b/tests/editorial/blog-preview-routing.test.ts
@@ -1,3 +1,4 @@
+import { isValidElement, type ReactElement, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -23,7 +24,30 @@ vi.mock("@/lib/editorial/http", () => ({
   requireEditor: mocks.requireEditor,
 }));
 
-import { generateMetadata } from "../../app/blog/[slug]/page";
+import BlogPostPage, { generateMetadata } from "../../app/blog/[slug]/page";
+
+function findImageBySource(
+  node: ReactNode,
+  source: string,
+): ReactElement<{ alt: string; src: string }> | null {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findImageBySource(child, source);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!isValidElement(node)) return null;
+  const props = node.props as {
+    alt?: string;
+    children?: ReactNode;
+    src?: string;
+  };
+  if (props.src === source) {
+    return node as ReactElement<{ alt: string; src: string }>;
+  }
+  return findImageBySource(props.children, source);
+}
 
 function post(slug: string, title: string, published: boolean) {
   return {
@@ -92,4 +116,33 @@ describe("blog preview routing", () => {
     expect(mocks.getPostBySlug).not.toHaveBeenCalled();
     expect(mocks.requireEditor).toHaveBeenCalledOnce();
   });
+
+  it.each([
+    ["decorative", "", ""],
+    [
+      "informative",
+      "A green abstract editorial image",
+      "A green abstract editorial image",
+    ],
+  ])(
+    "renders %s featured-image alt text without a fallback",
+    async (_label, alt, expected) => {
+      const slug = `render-${_label}`;
+      const source = "/media/asset:render-test";
+      mocks.getPostBySlug.mockResolvedValue({
+        ...post(slug, "Rendered article", true),
+        meta: {
+          ...post(slug, "Rendered article", true).meta,
+          featuredImage: source,
+          featuredImageAlt: alt,
+        },
+      });
+
+      const page = await BlogPostPage({ params: Promise.resolve({ slug }) });
+      const image = findImageBySource(page, source);
+
+      expect(image).not.toBeNull();
+      expect(image?.props.alt).toBe(expected);
+    },
+  );
 });

--- a/tests/editorial/blog-publication.test.ts
+++ b/tests/editorial/blog-publication.test.ts
@@ -55,11 +55,29 @@ describe("hybrid public blog publication", () => {
       content: published.body.source,
       meta: {
         featuredImage: "/media/asset:published",
+        featuredImageAlt: "A published editorial image",
         published: true,
         slug: published.slug,
       },
     });
     expect(mocks.repositoryBySlug).not.toHaveBeenCalled();
+  });
+
+  it("preserves an empty decorative alternative in the public view model", async () => {
+    const published = articleFixture({
+      featuredImage: {
+        altText: "",
+        assetId: "asset:decorative",
+        deliveryUrl: "https://shruggie.tech/media/asset:decorative",
+      },
+      publishedAt: "2026-09-10T12:00:00.000Z",
+      state: "published",
+    });
+    mocks.editorialBySlug.mockResolvedValue(published);
+
+    await expect(getPostBySlug(published.slug)).resolves.toMatchObject({
+      meta: { featuredImageAlt: "" },
+    });
   });
 
   it("merges published editorial articles and shadows repository copies", async () => {

--- a/tests/editorial/domain.test.ts
+++ b/tests/editorial/domain.test.ts
@@ -17,6 +17,26 @@ describe("articleSchemaV1", () => {
     ).toBe("published");
   });
 
+  it("normalizes blank image alternatives and preserves descriptive ones", () => {
+    const article = parseArticle(
+      articleFixture({
+        featuredImage: {
+          altText: " \t ",
+          assetId: "asset:decorative",
+          deliveryUrl: "https://shruggie.tech/media/asset:decorative",
+        },
+        ogImage: {
+          altText: "  A descriptive social card  ",
+          assetId: "asset:social",
+          deliveryUrl: "https://shruggie.tech/media/asset:social",
+        },
+      }),
+    );
+
+    expect(article.featuredImage?.altText).toBe("");
+    expect(article.ogImage?.altText).toBe("A descriptive social card");
+  });
+
   it.each([
     ["raw script", "<script>alert('no')</script>"],
     ["JSX", "<Callout>unsafe</Callout>"],

--- a/tests/editorial/mdx-reader.integration.test.ts
+++ b/tests/editorial/mdx-reader.integration.test.ts
@@ -53,4 +53,17 @@ describe("MdxArticleReader integration", () => {
       EditorialValidationError,
     );
   });
+
+  it("preserves explicitly blank decorative frontmatter alt text", async () => {
+    const directory = await temporaryPostsDirectory();
+    await writeFile(
+      path.join(directory, "decorative-image.mdx"),
+      '---\ntitle: "Decorative image"\ndate: "2026-09-05"\nauthor: "Natalie Thompson"\ncategory: "Engineering"\nexcerpt: "An article with an intentionally decorative featured image."\npublished: true\nfeaturedImage: "/images/decorative.png"\nfeaturedImageAlt: "   "\n---\n\n## Decorative\n\nSafe content.\n',
+    );
+    const reader = new MdxArticleReader(directory);
+
+    await expect(
+      reader.getBySlug("decorative-image", "published"),
+    ).resolves.toMatchObject({ featuredImage: { altText: "" } });
+  });
 });

--- a/tests/editorial/repository.test.ts
+++ b/tests/editorial/repository.test.ts
@@ -12,6 +12,35 @@ import { InMemoryArticleRepository } from "../../lib/editorial/memory-adapter";
 import { articleFixture, mutationContext, nextRevision } from "./fixtures";
 
 describe("ArticleRepository contract", () => {
+  it("persists normalized blank and descriptive image alternatives", async () => {
+    const repository = new InMemoryArticleRepository();
+    const article = articleFixture({
+      featuredImage: {
+        altText: "   ",
+        assetId: "asset:decorative",
+        deliveryUrl: "https://shruggie.tech/media/asset:decorative",
+      },
+      ogImage: {
+        altText: "  A descriptive social image  ",
+        assetId: "asset:social",
+        deliveryUrl: "https://shruggie.tech/media/asset:social",
+      },
+    });
+
+    const stored = await repository.create({
+      article,
+      idempotencyKey: "create-alt-example-0001",
+      mutation: mutationContext("request:create-alt-example-0001"),
+    });
+
+    expect(stored.featuredImage?.altText).toBe("");
+    expect(stored.ogImage?.altText).toBe("A descriptive social image");
+    await expect(repository.getById(article.id, "all")).resolves.toMatchObject({
+      featuredImage: { altText: "" },
+      ogImage: { altText: "A descriptive social image" },
+    });
+  });
+
   it("reserves slugs and returns actionable collisions", async () => {
     const repository = new InMemoryArticleRepository();
     await repository.create({

--- a/tests/editorial/vercel-google-credential.test.ts
+++ b/tests/editorial/vercel-google-credential.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { Storage } from "@google-cloud/storage";
 
 import {
+  createVercelExternalAccountOptions,
   externalAccountOptions,
   loadVercelGoogleCredentialConfig,
   VercelGoogleCredential,
@@ -30,8 +32,31 @@ describe("Vercel Google workload identity credential", () => {
     });
 
     await expect(
-      options.subject_token_supplier?.getSubjectToken({} as never),
+      options.subject_token_supplier.getSubjectToken(),
     ).resolves.toBe("vercel-token");
+  });
+
+  it("lets Storage create a compatible auth client that adds Authorization", async () => {
+    const storage = new Storage({
+      credentials: createVercelExternalAccountOptions(configuration),
+      projectId: "shruggie-web",
+    });
+    const client = await storage.authClient.getClient();
+    Object.assign(client, {
+      cachedAccessToken: {
+        access_token: "storage-token",
+        expiry_date: Date.now() + 3_600_000,
+        res: null,
+      },
+    });
+
+    const request = await storage.authClient.authorizeRequest({
+      url: "https://storage.googleapis.com/upload/storage/v1/b/example/o",
+    });
+
+    expect(request.headers).toMatchObject({
+      Authorization: "Bearer storage-token",
+    });
   });
 
   it("rejects incomplete or malformed production configuration", () => {

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -457,7 +457,7 @@ describe("EditorialWorkspace", () => {
     });
     await user.upload(screen.getByLabelText("Image file"), file);
     await user.type(
-      screen.getByLabelText("Descriptive alt text"),
+      screen.getByLabelText("Alt text (leave blank if decorative)"),
       "A green terminal window showing a successful build",
     );
     await user.click(screen.getByRole("button", { name: "Upload and use" }));
@@ -472,6 +472,81 @@ describe("EditorialWorkspace", () => {
       within(featured).getByRole("button", { name: "Remove image" }),
     );
     expect(within(featured).getByText("No image selected")).toBeVisible();
+  });
+
+  it("uploads decorative and informative images to either slot without losing draft data", async () => {
+    const user = userEvent.setup();
+    const fetchMock = sessionAndWorkspaceFetch();
+    globalThis.fetch = fetchMock;
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: "New article" }),
+    );
+    await user.type(screen.getByLabelText("Title"), "Preserved draft title");
+
+    const featured = screen.getByRole("group", { name: "Featured image" });
+    await user.click(
+      within(featured).getByRole("button", { name: "Choose image" }),
+    );
+    let dialog = screen.getByRole("dialog", {
+      name: "Choose featured image",
+    });
+    await user.click(
+      within(dialog).getAllByRole("button", { name: "Upload new" })[0],
+    );
+    await user.upload(
+      screen.getByLabelText("Image file"),
+      new File([new Uint8Array([137, 80, 78, 71])], "decorative.png", {
+        type: "image/png",
+      }),
+    );
+    await user.type(
+      screen.getByLabelText("Alt text (leave blank if decorative)"),
+      "   ",
+    );
+    await user.click(screen.getByRole("button", { name: "Upload and use" }));
+
+    expect(within(featured).getByText("decorative.png")).toBeVisible();
+    expect(within(featured).getByLabelText("Contextual alt text")).toHaveValue(
+      "",
+    );
+    expect(screen.getByLabelText("Title")).toHaveValue("Preserved draft title");
+
+    const social = screen.getByRole("group", { name: "Social image" });
+    await user.click(
+      within(social).getByRole("button", { name: "Choose image" }),
+    );
+    dialog = screen.getByRole("dialog", { name: "Choose social image" });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Upload new" }),
+    );
+    await user.upload(
+      screen.getByLabelText("Image file"),
+      new File([new Uint8Array([137, 80, 78, 71])], "social.png", {
+        type: "image/png",
+      }),
+    );
+    await user.type(
+      screen.getByLabelText("Alt text (leave blank if decorative)"),
+      "A green social preview card",
+    );
+    await user.click(screen.getByRole("button", { name: "Upload and use" }));
+
+    expect(within(social).getByText("social.png")).toBeVisible();
+    expect(within(social).getByLabelText("Contextual alt text")).toHaveValue(
+      "A green social preview card",
+    );
+    expect(screen.getByLabelText("Title")).toHaveValue("Preserved draft title");
+
+    const uploads = fetchMock.mock.calls.filter(
+      ([input, init]) =>
+        String(input) === "/api/admin/assets" && init?.method === "POST",
+    );
+    expect(uploads).toHaveLength(2);
+    expect((uploads[0]?.[1]?.body as FormData).get("altText")).toBe("");
+    expect((uploads[1]?.[1]?.body as FormData).get("altText")).toBe(
+      "A green social preview card",
+    );
   });
 
   it("loads a selected prior revision into the unsaved restore draft", async () => {


### PR DESCRIPTION
Refs #78

## Summary

- restore authenticated Firebase Storage uploads when Vercel external-account credentials are used
- normalize and persist intentionally blank image alt text while preserving non-empty alt text and media reuse
- add route, domain, repository, rendering, workspace, and credential regression coverage
- document the production diagnosis and verification steps

## Verification

- npm test
- npm run lint
- npx tsc --noEmit
- npm run build
- git diff --check

The local Firestore integration suite remains blocked on the documented Windows Java/Netty loopback failure. Issue #78 should remain open until post-deployment production upload and rendering verification is complete.