### PR TITLE
fix(cms): auto-save before preview and publish

### DIFF
--- a/components/editorial/EditorialWorkspace.tsx
+++ b/components/editorial/EditorialWorkspace.tsx
@@ -55,6 +55,7 @@ import SignInPanel from "./SignInPanel";
 type LoadState = "idle" | "loading" | "ready" | "error";
 type AssetSlot = "featuredImage" | "ogImage";
 type MutationAction = "publish" | "restore" | "save" | "unpublish";
+type EditorAction = MutationAction | "preview";
 
 interface PendingArticleMutation {
   action: MutationAction;
@@ -119,6 +120,20 @@ function articleAssetReference(asset: EditorialAsset): AssetReference {
 
 function stateLabel(state: Article["state"]): string {
   return state.charAt(0).toUpperCase() + state.slice(1);
+}
+
+function reservePreviewTab(): Window | null {
+  const previewTab = window.open("about:blank", "_blank");
+  if (previewTab) previewTab.opener = null;
+  return previewTab;
+}
+
+function navigatePreviewTab(previewTab: Window | null, url: string): void {
+  if (previewTab && !previewTab.closed) {
+    previewTab.location.replace(url);
+    return;
+  }
+  window.open(url, "_self");
 }
 
 export default function EditorialWorkspace() {
@@ -480,7 +495,7 @@ function ArticleEditor({
   onSessionFailure: (error: unknown) => boolean;
 }) {
   const [errors, setErrors] = useState<ArticleFieldErrors>({});
-  const [saveState, setSaveState] = useState<LoadState>("idle");
+  const [activeAction, setActiveAction] = useState<EditorAction | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [conflict, setConflict] = useState<string | null>(null);
   const [revisions, setRevisions] = useState<Article[]>([]);
@@ -493,6 +508,7 @@ function ArticleEditor({
   );
   const [pendingMutation, setPendingMutation] =
     useState<PendingArticleMutation | null>(null);
+  const actionLockRef = useRef(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const readOnly = draft.state === "archived";
   const markdownIssues = useMemo(
@@ -581,32 +597,34 @@ function ArticleEditor({
     applyChange(next);
   }
 
-  async function persistArticle(action: MutationAction) {
-    if (action !== "save" && !persisted) {
-      setMessage("Save the article as a draft before publishing it.");
-      return;
-    }
-    if (["publish", "unpublish"].includes(action) && dirty) {
-      setMessage("Save the current changes before changing publication state.");
-      return;
-    }
-
+  async function persistArticle(
+    action: MutationAction,
+    sourceDraft = draft,
+    basePersisted = persisted,
+    progressMessage?: string,
+    failureLabel = "Save",
+  ): Promise<Article | null> {
     const targetState =
       action === "publish"
         ? "published"
         : action === "unpublish" || action === "restore"
           ? "draft"
-          : persisted?.state === "published"
+          : basePersisted?.state === "published"
             ? "published"
             : "draft";
     const reusable =
       pendingMutation?.action === action ? pendingMutation : null;
     const candidate =
       reusable?.article ??
-      articleForSave(draft, editor.id, persisted, new Date(), targetState);
+      articleForSave(
+        sourceDraft,
+        editor.id,
+        basePersisted,
+        new Date(),
+        targetState,
+      );
     const nextErrors = validateArticleForSave(candidate);
     setErrors(nextErrors);
-    setMessage(null);
     setConflict(null);
     if (Object.keys(nextErrors).length) {
       setMessage(
@@ -616,17 +634,17 @@ function ArticleEditor({
         (path) => path !== "form",
       );
       if (firstField) document.getElementById(firstField)?.focus();
-      return;
+      return null;
     }
+    setMessage(progressMessage ?? "Saving…");
     const mutation: PendingArticleMutation = reusable ?? {
       action,
       article: candidate,
-      expectedRevision: persisted?.revision.number ?? null,
+      expectedRevision: basePersisted?.revision.number ?? null,
       idempotencyKey: editorialMutationKey(action),
       ...(restoreFromRevision === null ? {} : { restoreFromRevision }),
     };
     setPendingMutation(mutation);
-    setSaveState("loading");
     try {
       const saved =
         mutation.expectedRevision === null
@@ -656,7 +674,6 @@ function ArticleEditor({
                   ? `Published update saved as revision ${saved.revision.number}.`
                   : `Draft saved as revision ${saved.revision.number}.`,
       );
-      setSaveState("ready");
       setPendingMutation(null);
       setRestoreFromRevision(null);
       setSelectedRevision(null);
@@ -666,10 +683,10 @@ function ArticleEditor({
           (item) => item.revision.number !== saved.revision.number,
         ),
       ]);
+      return saved;
     } catch (error) {
       if (onSessionFailure(error)) {
-        setSaveState("error");
-        return;
+        return null;
       }
       if (
         error instanceof EditorialApiError &&
@@ -677,19 +694,113 @@ function ArticleEditor({
       ) {
         setConflict(error.message);
       } else {
-        setMessage(friendlyError(error));
+        setMessage(`${failureLabel} failed: ${friendlyError(error)}`);
       }
       if (!(error instanceof EditorialApiError) || !error.retryable) {
         setPendingMutation(null);
       }
-      setSaveState("error");
+      return null;
     }
   }
 
   async function saveDraft(event: React.FormEvent) {
     event.preventDefault();
-    if (readOnly) return;
-    await persistArticle("save");
+    if (readOnly || actionLockRef.current) return;
+    actionLockRef.current = true;
+    setActiveAction("save");
+    try {
+      await persistArticle("save", draft, persisted, "Saving draft…", "Save");
+    } finally {
+      actionLockRef.current = false;
+      setActiveAction(null);
+    }
+  }
+
+  async function previewArticle() {
+    if (readOnly || actionLockRef.current) return;
+    actionLockRef.current = true;
+    const previewTab = reservePreviewTab();
+    setActiveAction("preview");
+    try {
+      let previewSource = persisted;
+      if (!previewSource || dirty) {
+        const publishingUpdate = draft.state === "published";
+        previewSource = await persistArticle(
+          "save",
+          draft,
+          persisted,
+          publishingUpdate
+            ? "Publishing the current update before opening preview…"
+            : "Saving the current draft before opening preview…",
+          "Preview",
+        );
+      }
+      if (!previewSource) {
+        previewTab?.close();
+        return;
+      }
+      setMessage("Opening preview…");
+      navigatePreviewTab(
+        previewTab,
+        `/api/admin/preview?slug=${encodeURIComponent(previewSource.slug)}`,
+      );
+      setMessage(
+        `Preview opened for revision ${previewSource.revision.number}.`,
+      );
+    } finally {
+      actionLockRef.current = false;
+      setActiveAction(null);
+    }
+  }
+
+  async function publishArticle() {
+    if (readOnly || actionLockRef.current || draft.state !== "draft") return;
+    actionLockRef.current = true;
+    setActiveAction("publish");
+    try {
+      let basePersisted = persisted;
+      let sourceDraft = draft;
+      if (!basePersisted) {
+        const savedDraft = await persistArticle(
+          "save",
+          draft,
+          null,
+          "Saving the new draft before publishing…",
+          "Publish",
+        );
+        if (!savedDraft) return;
+        basePersisted = savedDraft;
+        sourceDraft = savedDraft;
+      }
+      await persistArticle(
+        "publish",
+        sourceDraft,
+        basePersisted,
+        "Publishing…",
+        "Publish",
+      );
+    } finally {
+      actionLockRef.current = false;
+      setActiveAction(null);
+    }
+  }
+
+  async function runMutation(action: "restore" | "unpublish") {
+    if (actionLockRef.current) return;
+    actionLockRef.current = true;
+    setActiveAction(action);
+    try {
+      await persistArticle(
+        action,
+        draft,
+        persisted,
+        action === "restore" ? "Restoring draft…" : "Unpublishing…",
+        action === "restore" ? "Restore" : "Unpublish",
+      );
+    } finally {
+      actionLockRef.current = false;
+      setActiveAction(null);
+    }
   }
 
   async function reloadLatest() {
@@ -1011,11 +1122,11 @@ function ArticleEditor({
             <Button
               type="submit"
               size="sm"
-              disabled={readOnly || saveState === "loading"}
+              disabled={readOnly || activeAction !== null}
               className="shrink-0 whitespace-nowrap"
             >
               <Save aria-hidden="true" className="mr-2" size={18} />{" "}
-              {saveState === "loading"
+              {activeAction === "save"
                 ? "Saving…"
                 : restoreFromRevision !== null
                   ? "Restore revision"
@@ -1027,43 +1138,36 @@ function ArticleEditor({
               type="button"
               variant="secondary"
               size="sm"
-              disabled={!persisted || dirty || draft.state === "archived"}
+              disabled={draft.state === "archived" || activeAction !== null}
               aria-describedby="preview-note"
               className="shrink-0 whitespace-nowrap"
-              onClick={() => {
-                if (!persisted || dirty) return;
-                window.open(
-                  `/api/admin/preview?slug=${encodeURIComponent(persisted.slug)}`,
-                  "_blank",
-                  "noopener,noreferrer",
-                );
-              }}
+              onClick={() => void previewArticle()}
             >
-              <Eye aria-hidden="true" className="mr-2" size={18} /> Preview
+              <Eye aria-hidden="true" className="mr-2" size={18} />{" "}
+              {activeAction === "preview" ? "Preparing preview…" : "Preview"}
             </Button>
             <Button
               type="button"
               variant="secondary"
               size="sm"
-              disabled={
-                !persisted ||
-                dirty ||
-                persisted.state !== "draft" ||
-                saveState === "loading"
-              }
+              disabled={draft.state !== "draft" || activeAction !== null}
               className="shrink-0 whitespace-nowrap"
-              onClick={() => void persistArticle("publish")}
+              onClick={() => void publishArticle()}
             >
-              Publish
+              {activeAction === "publish"
+                ? persisted
+                  ? "Publishing…"
+                  : "Saving and publishing…"
+                : "Publish"}
             </Button>
             {persisted?.state === "published" && (
               <Button
                 type="button"
                 variant="secondary"
                 size="sm"
-                disabled={dirty || saveState === "loading"}
+                disabled={dirty || activeAction !== null}
                 className="shrink-0 whitespace-nowrap"
-                onClick={() => void persistArticle("unpublish")}
+                onClick={() => void runMutation("unpublish")}
               >
                 Unpublish
               </Button>
@@ -1073,9 +1177,9 @@ function ArticleEditor({
                 type="button"
                 variant="secondary"
                 size="sm"
-                disabled={saveState === "loading"}
+                disabled={activeAction !== null}
                 className="shrink-0 whitespace-nowrap"
-                onClick={() => void persistArticle("restore")}
+                onClick={() => void runMutation("restore")}
               >
                 Restore to draft
               </Button>
@@ -1085,14 +1189,16 @@ function ArticleEditor({
               className="text-body-xs text-text-secondary min-w-0 flex-1 sm:text-right"
             >
               {!persisted
-                ? "Save the draft to preview."
-                : dirty
-                  ? "Save changes to refresh the preview."
-                  : persisted.state === "published"
-                    ? "Changes remain private until you publish the update."
-                    : persisted.state === "archived"
-                      ? "Restore this article before editing or previewing it."
-                      : "Preview opens the saved draft without publishing."}
+                ? "Preview saves this draft automatically. Publish saves and publishes it in one action."
+                : dirty && persisted.state === "published"
+                  ? "Preview publishes the current update before opening it."
+                  : dirty
+                    ? "Preview and Publish save the current changes automatically."
+                    : persisted.state === "published"
+                      ? "Preview opens the current published revision."
+                      : persisted.state === "archived"
+                        ? "Restore this article before editing or previewing it."
+                        : "Preview opens the saved draft without publishing."}
             </p>
           </div>
         </form>

--- a/docs/editorial/authoring-workspace.md
+++ b/docs/editorial/authoring-workspace.md
@@ -16,24 +16,33 @@ contracts from #25 and the server session boundary from #26.
    proposes a canonical slug when the slug is still empty.
 4. Upload or select featured and social images. Every upload requires
    contextual alternative text and is revalidated by the server.
-5. Choose **Save draft**. Validation moves focus to the first invalid field and
-   does not clear any unsaved values.
-6. Choose **Preview** to open the latest saved revision through the public
-   article template. Unsaved changes are never included in preview.
-7. Choose **Publish** from a clean saved draft. The server commits the
-   publication revision and audit event before invalidating the article, blog
-   index, pagination, sitemap, metadata, and referenced media surfaces.
+5. Choose **Save draft** whenever you want a private revision checkpoint. This
+   remains optional before Preview or Publish. Validation moves focus to the
+   first invalid field and does not clear any unsaved values.
+6. Choose **Preview** to save a new or changed draft automatically and open that
+   exact revision through the public article template. If a browser blocks the
+   reserved preview tab, the workspace falls back to same-tab navigation.
+7. Choose **Publish** once from a new, changed, or clean draft. The workspace
+   performs any required draft creation automatically, then the server commits
+   the publication revision and audit event before invalidating the article,
+   blog index, pagination, sitemap, metadata, and referenced media surfaces.
 8. Open a published article to make corrections, then choose **Publish update**
    to save a new public revision without changing its original publication
-   date. Choose **Unpublish** only after saving or discarding local changes.
+   date. Because published articles do not have a separate private working
+   copy, choosing **Preview** with pending published edits clearly publishes the
+   update before opening it. Choose **Unpublish** only after saving or
+   discarding local changes.
 9. Use revision history to inspect an earlier immutable snapshot. Loading and
    saving that snapshot creates a new revision with an explicit `restore` audit
    event; it never overwrites history. Archived articles can be restored to a
    draft before editing.
 
-Draft saving, preview, and public publishing remain separate actions. New
-published slugs are resolved from Firestore at request time and do not require
-a repository commit or application deployment.
+Draft saving, preview, and public publishing remain distinct outcomes, but
+Preview and Publish perform their save prerequisites automatically. The action
+bar reports whether it is saving, opening a preview, publishing, restoring, or
+unpublishing, and prevents duplicate activation while an action is in flight.
+New published slugs are resolved from Firestore at request time and do not
+require a repository commit or application deployment.
 
 ## Public delivery during migration
 

--- a/tests/editorial/workspace.test.tsx
+++ b/tests/editorial/workspace.test.tsx
@@ -92,6 +92,37 @@ function sessionAndWorkspaceFetch(
   });
 }
 
+function previewTabStub() {
+  const close = vi.fn();
+  const replace = vi.fn();
+  return {
+    close,
+    replace,
+    tab: {
+      close,
+      closed: false,
+      location: { replace },
+      opener: window,
+    } as unknown as Window,
+  };
+}
+
+async function completeNewArticle(
+  user: ReturnType<typeof userEvent.setup>,
+  title: string,
+) {
+  const titleField = screen.getByLabelText("Title");
+  await user.type(titleField, title);
+  await user.tab();
+  await user.type(screen.getByLabelText("Category"), "Engineering");
+  await user.type(
+    screen.getByLabelText("Excerpt"),
+    "A complete excerpt for testing the one-click editorial workflow.",
+  );
+  await user.click(screen.getByLabelText("Article body in Markdown"));
+  await user.paste("## A useful heading\n\nA safe article body.");
+}
+
 beforeEach(() => {
   sessionStorage.clear();
   Object.defineProperties(Range.prototype, {
@@ -209,15 +240,17 @@ describe("EditorialWorkspace", () => {
     await user.paste("## A useful heading\n\nA safe article body.");
 
     const preview = screen.getByRole("button", { name: "Preview" });
-    expect(preview).toBeDisabled();
-    expect(screen.getByText("Save the draft to preview.")).toBeInTheDocument();
-
-    const save = screen.getByRole("button", { name: "Save draft" });
-    save.focus();
+    expect(preview).toBeEnabled();
+    expect(
+      screen.getByText(/Preview saves this draft automatically/),
+    ).toBeInTheDocument();
+    const previewTab = previewTabStub();
+    const open = vi.spyOn(window, "open").mockReturnValue(previewTab.tab);
+    preview.focus();
     await user.keyboard("{Enter}");
 
     expect(await screen.findByRole("status")).toHaveTextContent(
-      "Draft saved as revision 1.",
+      "Preview opened for revision 1.",
     );
     const post = fetchMock.mock.calls.find(
       ([input, init]) =>
@@ -230,15 +263,9 @@ describe("EditorialWorkspace", () => {
       name: "William Thompson",
     });
     expect(preview).toBeEnabled();
-    expect(
-      screen.getByText("Preview opens the saved draft without publishing."),
-    ).toBeInTheDocument();
-    const open = vi.spyOn(window, "open").mockReturnValue(null);
-    await user.click(preview);
-    expect(open).toHaveBeenCalledWith(
+    expect(open).toHaveBeenCalledWith("about:blank", "_blank");
+    expect(previewTab.replace).toHaveBeenCalledWith(
       "/api/admin/preview?slug=a-keyboard-authored-article",
-      "_blank",
-      "noopener,noreferrer",
     );
     const publish = screen.getByRole("button", { name: "Publish" });
     expect(publish).toBeEnabled();
@@ -266,6 +293,248 @@ describe("EditorialWorkspace", () => {
       rules: { "color-contrast": { enabled: false } },
     });
     expect(accessibility.violations).toEqual([]);
+  });
+
+  it("publishes a valid new article without a separate draft-save click", async () => {
+    const fetchMock = sessionAndWorkspaceFetch();
+    globalThis.fetch = fetchMock;
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: "New article" }),
+    );
+    await completeNewArticle(user, "One-click publication");
+
+    const publish = screen.getByRole("button", { name: "Publish" });
+    expect(publish).toBeEnabled();
+    await user.click(publish);
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Published revision 2",
+    );
+    const writes = fetchMock.mock.calls.filter(([, init]) =>
+      ["POST", "PUT"].includes(init?.method ?? ""),
+    );
+    expect(writes).toHaveLength(2);
+    expect(String(writes[0]?.[0])).toBe("/api/admin/articles");
+    expect(String(writes[1]?.[0])).toContain("/api/admin/articles/");
+    const created = JSON.parse(String(writes[0]?.[1]?.body)) as {
+      article: Article;
+    };
+    const published = JSON.parse(String(writes[1]?.[1]?.body)) as {
+      article: Article;
+    };
+    expect(created.article).toMatchObject({ state: "draft" });
+    expect(published.article).toMatchObject({
+      state: "published",
+      title: "One-click publication",
+    });
+  });
+
+  it("saves a dirty draft and opens its resulting preview in one click", async () => {
+    const current = articleFixture();
+    const fetchMock = sessionAndWorkspaceFetch([current], [current]);
+    globalThis.fetch = fetchMock;
+    const previewTab = previewTabStub();
+    vi.spyOn(window, "open").mockReturnValue(previewTab.tab);
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: /Edit An example article/ }),
+    );
+    const title = screen.getByLabelText("Title");
+    await user.clear(title);
+    await user.type(title, "Preview the current changes");
+
+    await user.click(screen.getByRole("button", { name: "Preview" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Preview opened for revision 2",
+    );
+    const updateCalls = fetchMock.mock.calls.filter(
+      ([input, init]) =>
+        String(input).includes("/api/admin/articles/") &&
+        init?.method === "PUT",
+    );
+    expect(updateCalls).toHaveLength(1);
+    const saved = JSON.parse(String(updateCalls[0]?.[1]?.body)) as {
+      article: Article;
+    };
+    expect(saved.article).toMatchObject({
+      state: "draft",
+      title: "Preview the current changes",
+    });
+    expect(previewTab.replace).toHaveBeenCalledWith(
+      `/api/admin/preview?slug=${current.slug}`,
+    );
+  });
+
+  it("publishes pending edits before previewing a published article", async () => {
+    const publishedAt = "2026-09-06T12:00:00.000Z";
+    const current = articleFixture({ state: "published", publishedAt });
+    const fetchMock = sessionAndWorkspaceFetch([current], [current]);
+    globalThis.fetch = fetchMock;
+    const previewTab = previewTabStub();
+    vi.spyOn(window, "open").mockReturnValue(previewTab.tab);
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: /Edit An example article/ }),
+    );
+    const title = screen.getByLabelText("Title");
+    await user.clear(title);
+    await user.type(title, "Published update preview");
+    expect(
+      screen.getByText(
+        "Preview publishes the current update before opening it.",
+      ),
+    ).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Preview" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Preview opened for revision 2",
+    );
+    const update = fetchMock.mock.calls.find(
+      ([input, init]) =>
+        String(input).includes("/api/admin/articles/") &&
+        init?.method === "PUT",
+    );
+    const saved = JSON.parse(String(update?.[1]?.body)) as {
+      article: Article;
+    };
+    expect(saved.article).toMatchObject({
+      publishedAt,
+      state: "published",
+      title: "Published update preview",
+    });
+    expect(previewTab.replace).toHaveBeenCalledWith(
+      `/api/admin/preview?slug=${current.slug}`,
+    );
+  });
+
+  it("publishes dirty draft changes in one update", async () => {
+    const current = articleFixture();
+    const fetchMock = sessionAndWorkspaceFetch([current], [current]);
+    globalThis.fetch = fetchMock;
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: /Edit An example article/ }),
+    );
+    const title = screen.getByLabelText("Title");
+    await user.clear(title);
+    await user.type(title, "Publish the current changes");
+
+    await user.click(screen.getByRole("button", { name: "Publish" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Published revision 2",
+    );
+    const writes = fetchMock.mock.calls.filter(([, init]) =>
+      ["POST", "PUT"].includes(init?.method ?? ""),
+    );
+    expect(writes).toHaveLength(1);
+    const published = JSON.parse(String(writes[0]?.[1]?.body)) as {
+      article: Article;
+    };
+    expect(published.article).toMatchObject({
+      state: "published",
+      title: "Publish the current changes",
+    });
+  });
+
+  it("prevents duplicate publication while the automatic save is pending", async () => {
+    let releaseCreate: (() => void) | undefined;
+    const createPending = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    const baseFetch = sessionAndWorkspaceFetch();
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (
+          String(input) === "/api/admin/articles" &&
+          init?.method === "POST"
+        ) {
+          await createPending;
+        }
+        return baseFetch(input, init);
+      },
+    );
+    globalThis.fetch = fetchMock;
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: "New article" }),
+    );
+    await completeNewArticle(user, "No duplicate publication");
+
+    const publish = screen.getByRole("button", { name: "Publish" });
+    const firstClick = user.click(publish);
+    await screen.findByRole("button", { name: "Saving and publishing…" });
+    expect(publish).toBeDisabled();
+    publish.click();
+    expect(
+      fetchMock.mock.calls.filter(
+        ([input, init]) =>
+          String(input) === "/api/admin/articles" && init?.method === "POST",
+      ),
+    ).toHaveLength(1);
+
+    releaseCreate?.();
+    await firstClick;
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Published revision 2",
+    );
+  });
+
+  it("closes a reserved preview tab when automatic saving fails validation", async () => {
+    const previewTab = previewTabStub();
+    vi.spyOn(window, "open").mockReturnValue(previewTab.tab);
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: "New article" }),
+    );
+    await user.type(screen.getByLabelText("Title"), "Incomplete article");
+
+    await user.click(screen.getByRole("button", { name: "Preview" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Review the highlighted fields",
+    );
+    expect(previewTab.close).toHaveBeenCalledOnce();
+    expect(
+      vi
+        .mocked(globalThis.fetch)
+        .mock.calls.some(([, init]) => init?.method === "POST"),
+    ).toBe(false);
+  });
+
+  it("falls back to same-tab preview navigation when a popup is blocked", async () => {
+    const current = articleFixture();
+    const fetchMock = sessionAndWorkspaceFetch([current], [current]);
+    globalThis.fetch = fetchMock;
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    const user = userEvent.setup();
+    render(<EditorialWorkspace />);
+    await user.click(
+      await screen.findByRole("button", { name: /Edit An example article/ }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Preview" }));
+
+    expect(open).toHaveBeenNthCalledWith(1, "about:blank", "_blank");
+    expect(open).toHaveBeenNthCalledWith(
+      2,
+      `/api/admin/preview?slug=${current.slug}`,
+      "_self",
+    );
+    expect(
+      fetchMock.mock.calls.some(([, init]) =>
+        ["POST", "PUT"].includes(init?.method ?? ""),
+      ),
+    ).toBe(false);
   });
 
   it("keeps article-body scrolling inside the editor", async () => {


### PR DESCRIPTION
## Summary

- make Preview automatically save new or dirty articles before opening the exact resulting revision
- make Publish create the required initial draft for new articles and publish dirty drafts without an extra manual action
- add explicit busy, success, validation, conflict, and failure feedback with duplicate-action locking
- reserve the preview tab synchronously and fall back to same-tab navigation when popups are blocked
- document and test the one-click editorial workflow

## Verification

- `npm exec vitest run tests/editorial/workspace.test.tsx` (21 passed)
- `npm exec tsc -- --noEmit`
- `npm test` (4 contrast tests and 84 editorial tests passed)
- `npm run lint`
- `npm run build`

The production build retains the repository's existing Edge Runtime deprecation warning.

Closes #79

