### PR TITLE
fix(blog): decouple builds from editorial storage

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -4,7 +4,8 @@
  * Renders a full blog post with PostHeader, MDX body (via next-mdx-remote/rsc),
  * Shiki syntax highlighting, and BlogPosting JSON-LD schema.
  *
- * Uses generateStaticParams to pre-render all published posts at build time.
+ * Uses generateStaticParams to pre-render repository posts at build time.
+ * Editorial-only slugs render on demand so builds do not depend on Firestore.
  *
  * Spec references: §7.2 (MDX Pipeline), §7.3 (Blog Post Template), §8.2 (JSON-LD)
  */
@@ -19,9 +20,9 @@ import { cache } from "react";
 
 import { SITE_URL, getOgImageUrl } from "@/lib/constants";
 import {
-  getAllPostsMeta,
   getPostBySlug,
   getPreviewPostBySlug,
+  getRepositoryPostSlugs,
 } from "@/lib/blog";
 import { requireEditor } from "@/lib/editorial/http";
 import { ArticleNotFoundError } from "@/lib/editorial/errors";
@@ -70,8 +71,8 @@ const getPostForRequest = cache(async (slug: string) => {
 });
 
 export async function generateStaticParams() {
-  const posts = await getAllPostsMeta();
-  return posts.map((post) => ({ slug: post.slug }));
+  const slugs = await getRepositoryPostSlugs();
+  return slugs.map((slug) => ({ slug }));
 }
 
 export async function generateMetadata({

--- a/docs/editorial/authoring-workspace.md
+++ b/docs/editorial/authoring-workspace.md
@@ -44,6 +44,11 @@ unpublishing, and prevents duplicate activation while an action is in flight.
 New published slugs are resolved from Firestore at request time and do not
 require a repository commit or application deployment.
 
+Build-time route enumeration reads repository-backed slugs only. CMS-only
+slugs use the dynamic route fallback on first request, so a slow or unavailable
+editorial store cannot abort an otherwise valid application build after its
+article index was read successfully.
+
 ## Public delivery during migration
 
 Until the migration in #29 is complete, `lib/blog.ts` merges published

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -100,6 +100,17 @@ export async function getAllPostsMeta(): Promise<PostMeta[]> {
   }
 }
 
+/**
+ * Keep build-time route enumeration independent of the remote editorial store.
+ * CMS-only slugs are served on demand because dynamicParams defaults to true.
+ */
+export async function getRepositoryPostSlugs(): Promise<string[]> {
+  const repositoryArticles = await articleReader.list({
+    visibility: "published",
+  });
+  return repositoryArticles.map((article) => article.slug);
+}
+
 export async function getPostBySlug(slug: string): Promise<{
   content: string;
   meta: PostMeta;

--- a/tests/editorial/blog-preview-routing.test.ts
+++ b/tests/editorial/blog-preview-routing.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   draftMode: vi.fn(),
   getPostBySlug: vi.fn(),
   getPreviewPostBySlug: vi.fn(),
+  getRepositoryPostSlugs: vi.fn(),
   headers: vi.fn(),
   requireEditor: vi.fn(),
 }));
@@ -18,13 +19,17 @@ vi.mock("@/lib/blog", () => ({
   getAllPostsMeta: vi.fn(async () => []),
   getPostBySlug: mocks.getPostBySlug,
   getPreviewPostBySlug: mocks.getPreviewPostBySlug,
+  getRepositoryPostSlugs: mocks.getRepositoryPostSlugs,
 }));
 
 vi.mock("@/lib/editorial/http", () => ({
   requireEditor: mocks.requireEditor,
 }));
 
-import BlogPostPage, { generateMetadata } from "../../app/blog/[slug]/page";
+import BlogPostPage, {
+  generateMetadata,
+  generateStaticParams,
+} from "../../app/blog/[slug]/page";
 
 function findImageBySource(
   node: ReactNode,
@@ -76,9 +81,23 @@ beforeEach(() => {
     role: "admin",
     uid: "firebase-user",
   });
+  mocks.getRepositoryPostSlugs.mockResolvedValue([]);
 });
 
 describe("blog preview routing", () => {
+  it("generates build-time params from repository slugs only", async () => {
+    mocks.getRepositoryPostSlugs.mockResolvedValue([
+      "repository-one",
+      "repository-two",
+    ]);
+
+    await expect(generateStaticParams()).resolves.toEqual([
+      { slug: "repository-one" },
+      { slug: "repository-two" },
+    ]);
+    expect(mocks.getRepositoryPostSlugs).toHaveBeenCalledOnce();
+  });
+
   it("uses published content when Draft Mode remains enabled without an exact preview slug", async () => {
     mocks.getPostBySlug.mockResolvedValue(
       post("published-article", "Published article", true),

--- a/tests/editorial/blog-publication.test.ts
+++ b/tests/editorial/blog-publication.test.ts
@@ -27,7 +27,11 @@ vi.mock("../../lib/editorial/firebase-admin", () => ({
   createFirebaseEditorialBackend: vi.fn(),
 }));
 
-import { getAllPostsMeta, getPostBySlug } from "../../lib/blog";
+import {
+  getAllPostsMeta,
+  getPostBySlug,
+  getRepositoryPostSlugs,
+} from "../../lib/blog";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -104,6 +108,24 @@ describe("hybrid public blog publication", () => {
         title: "Editorial version",
       }),
     ]);
+  });
+
+  it("enumerates repository slugs at build time without reading the editorial backend", async () => {
+    const repositoryArticle = articleFixture({
+      id: "article:repository",
+      slug: "repository-build-slug",
+      state: "published",
+      publishedAt: "2026-09-01T12:00:00.000Z",
+    });
+    mocks.repositoryList.mockResolvedValue([repositoryArticle]);
+
+    await expect(getRepositoryPostSlugs()).resolves.toEqual([
+      "repository-build-slug",
+    ]);
+    expect(mocks.repositoryList).toHaveBeenCalledWith({
+      visibility: "published",
+    });
+    expect(mocks.editorialList).not.toHaveBeenCalled();
   });
 
   it("keeps an unpublished editorial slug from falling through to repository content", async () => {


### PR DESCRIPTION
## Summary

- enumerate only repository-backed blog slugs during `generateStaticParams`
- keep CMS-only published slugs available through the default dynamic route fallback
- prevent a transient Firestore read timeout from aborting an otherwise valid Vercel build
- add regression coverage for the build-time source boundary and document the runtime behavior

## Failure addressed

The production deployment for merge commit `7ac2fad` compiled and passed TypeScript, then failed while prerendering the CMS-only slug `your-ai-problem-might-be-an-architecture-problem`. The editorial index read had succeeded, but the subsequent per-slug Firestore read exceeded the 5000 ms content timeout, causing static export to abort.

This follow-up keeps stable repository posts statically generated while rendering CMS-only slugs on demand, as supported by Next.js `dynamicParams: true` behavior.

## Verification

- `npm exec vitest run tests/editorial/blog-publication.test.ts tests/editorial/blog-preview-routing.test.ts` (11 passed)
- `npm test` (4 contrast tests and 98 editorial tests passed)
- `npm run lint`
- `npm run build` (32 static pages generated; CMS-only slug excluded from prerendering)

The build retains the repository's existing Edge Runtime deprecation warning.

Follow-up to #81. Coordinates with #28.

